### PR TITLE
Remove duplicate slash in www. redirect

### DIFF
--- a/config/lutrisweb.conf
+++ b/config/lutrisweb.conf
@@ -13,7 +13,7 @@
 
     RewriteEngine On
     RewriteCond %{HTTP_HOST} ^www\.(.+)$ [NC]
-    RewriteRule ^(.*)$ http://%1/$1 [R=301,L]
+    RewriteRule ^(.*)$ http://%1$1 [R=301,L]
 
     <Location "/">
         Order Allow,Deny


### PR DESCRIPTION
The slash is already included in either `%1`or `$1` (I can't remember which).
