### PR TITLE
Link to https:// where possible.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Getting the site up and running for development
 
 If you haven't done it already, install and configure virtualenvwrapper.
 If you are unfamiliar with virtualenvwrapper, see their documentation on
-their website: http://virtualenvwrapper.readthedocs.org/en/latest/
+their website: https://virtualenvwrapper.readthedocs.org/en/latest/
 
 ::
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -83,7 +83,7 @@
                 </a>
               </li>
               <li>
-                <a href="http://steamcommunity.com/groups/lutris">
+                <a href="https://steamcommunity.com/groups/lutris">
                   <img src="{{ STATIC_URL }}images/icons/steam-32.png" title="Steam">
                 </a>
               </li>
@@ -112,13 +112,13 @@
           <div class="col-sm-5">
             <h5>Gaming news</h5>
             <ul>
-              <li><a href="http://rootgamer.com/">Root Gamer</a></li>
-              <li><a href="http://linuxgamecast.com/">LinuxGameCast</a>
+              <li><a href="https://rootgamer.com/">Root Gamer</a></li>
+              <li><a href="https://linuxgamecast.com/">LinuxGameCast</a>
               <li><a href="http://www.linuxgamenews.com/">Linux Game News</a>
-              <li><a href="http://www.gamingonlinux.com/">Gaming on Linux</a>
-              <li><a href="http://www.playonlinux.com">PlayOnLinux</a>
+              <li><a href="https://www.gamingonlinux.com/">Gaming on Linux</a>
+              <li><a href="https://www.playonlinux.com">PlayOnLinux</a>
               <li><a href="http://www.penguspy.com">Pengu Spy</a>
-              <li><a href="http://www.reddit.com/r/linux_gaming/">/r/linux_gaming</a>
+              <li><a href="https://www.reddit.com/r/linux_gaming/">/r/linux_gaming</a>
             </ul>
           </div>
           <div class="col-sm-2">

--- a/templates/common/about.html
+++ b/templates/common/about.html
@@ -178,7 +178,7 @@
         we also maintain the emulators shipped with Lutris, you can help by
         sending patches for better fullscreen or controller support or anything
         you can think of that would make these emulators better. You can get
-        most of them at <a href="http://github.com/lutris">github.com/lutris</a>.
+        most of them at <a href="https://github.com/lutris">github.com/lutris</a>.
       </p>
       <p>
         To discuss development you can subscribe to our

--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -56,7 +56,7 @@
         <p>
           Packages and repositories for current versions of Fedora and openSUSE
           are available from the
-          <a href="http://software.opensuse.org/download.html?project=home%3Astrycore&package=lutris">openSUSE Build Service</a>
+          <a href="https://software.opensuse.org/download.html?project=home%3Astrycore&package=lutris">openSUSE Build Service</a>
         </p>
       </li>
       <li>
@@ -81,7 +81,7 @@
         </ul>
         <p>
         Lutris is available in the official Gentoo repositories:
-        <a href="http://packages.gentoo.org/package/games-util/lutris">http://packages.gentoo.org/package/games-util/lutris</a>.
+        <a href="https://packages.gentoo.org/package/games-util/lutris">https://packages.gentoo.org/package/games-util/lutris</a>.
         </p>
       </li>
       <li>
@@ -92,7 +92,7 @@
         </ul>
         <p>
         Lutris is available from the SlackBuilds repositories:
-        <a href="http://slackbuilds.org/apps/lutris/">http://slackbuilds.org/apps/lutris/</a>.
+        <a href="https://slackbuilds.org/apps/lutris/">https://slackbuilds.org/apps/lutris/</a>.
         </p>
       </li>
       <li>
@@ -117,7 +117,7 @@
         <p>
         Lutris is constantly evolving. If you want to try out the latest
         features or help with the development, you can get Lutris from Github:<br/>
-        <code>git clone http://github.com/lutris/lutris.git</code><br/>
+        <code>git clone https://github.com/lutris/lutris.git</code><br/>
         Please report all problems on the
         <a href="https://github.com/lutris/lutris/issues">bugtracker</a>
           or on
@@ -128,7 +128,7 @@
     <p class="footnote right">
     Icons by
     <a href='http://www.fatcow.com/free-icons'>FatCow</a> under
-    <a href="http://creativecommons.org/licenses/by/3.0/us/">CC-BY-3.0-US</a>
+    <a href="https://creativecommons.org/licenses/by/3.0/us/">CC-BY-3.0-US</a>
     </p>
   </div>
 </div>

--- a/templates/games/detail.html
+++ b/templates/games/detail.html
@@ -98,7 +98,7 @@
             </a>
             {% endif %}
             {% if game.gogid %}
-            <a href="http://www.gog.com/game/{{ game.gogid }}" title="GOG.com" class='external-link'>
+            <a href="https://www.gog.com/game/{{ game.gogid }}" title="GOG.com" class='external-link'>
               <img src="{{ STATIC_URL }}images/icons/gog.png" alt="GOG" />
               <span>GOG</span>
             </a>

--- a/templates/games/submit.html
+++ b/templates/games/submit.html
@@ -12,7 +12,7 @@
       <h1>Submit a game</h1>
       <p>
         Please be as accurate as possible with the information you provide.
-        Wikipedia or <a href="http://www.mobygames.com/search/quick">Mobygames</a>
+        Wikipedia or <a href="https://www.mobygames.com/search/quick">Mobygames</a>
         are generally reliable sources. If you know more accurate ones, let us
         know! Thanks for your efforts!<br /><br />
       </p>


### PR DESCRIPTION
Let's do our part in encrypting as much web traffic as possible. :)

A few of these will redirect HTTP→HTTPS on their own, but far most will let you happily browse their site using HTTP, if that's how you end up there.