### PR TITLE
Make Atom news feed discoverable.

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -3,6 +3,9 @@
 {% load humanize %}
 {% load lutris %}
 
+{% block extra_head %}
+<link href="/news/feed/" rel="alternate" type="application/atom+xml" title="Lutris news - Atom" />
+{% endblock %}
 
 {% block content %}
 

--- a/templates/news.html
+++ b/templates/news.html
@@ -1,6 +1,10 @@
 {% extends "base.html" %}
 {% block title %}News - Lutris{% endblock %}
 
+{% block extra_head %}
+<link href="/news/feed/" rel="alternate" type="application/atom+xml" title="Lutris news - Atom" />
+{% endblock %}
+
 {% block content %}
 <div class="row">
   <div class="col-md-2"></div>


### PR DESCRIPTION
Possibly enough to fix https://github.com/lutris/website/issues/63 - but maybe we'll want links to the feed in the content as well?