### PR TITLE
Issue 45: Auto-installer should be hidden if there's a (published) manual installer for the same platform

### DIFF
--- a/templates/games/detail.html
+++ b/templates/games/detail.html
@@ -140,7 +140,7 @@
           {% endfor %}
         </ul>
         {% endif %}
-        {% if auto_installers %}
+        {% elif auto_installers%}
         <ul>
           {% for installer in auto_installers %}
             {% include "games/_installer.html" %}


### PR DESCRIPTION
Should fix #45 