### PR TITLE
Show installer's last update

### DIFF
--- a/public/components/installer-pane.html
+++ b/public/components/installer-pane.html
@@ -4,13 +4,14 @@
   <template>
     <div class="pane">
       <p>
-        <strong>ID:</strong><span>[[installer.id]]</span><br/>
-        <strong>Author:</strong><span>[[installer.user]]</span><br/>
-        <strong>Date:</strong><span>[[installer.created_at]]</span><br/>
-        <strong>Version:</strong><span>[[installer.version]]</span><br/>
-        <strong>Runner:</strong><span>[[installer.runner]]</span><br/>
-        <strong>Draft:</strong><input type="checkbox" disabled checked="[[installer.draft]]"><br/>
-        <strong>Published:</strong><input type="checkbox" disabled checked="[[installer.published]]">
+        <strong>ID: </strong><span>[[installer.id]]</span><br/>
+        <strong>Author: </strong><span>[[installer.user]]</span><br/>
+        <strong>Created on: </strong><span>[[installer.created_at]]</span><br/>
+        <strong>Last Updated on: </strong><span>[[installer.updated_at]]</span><br/>
+        <strong>Version: </strong><span>[[installer.version]]</span><br/>
+        <strong>Runner: </strong><span>[[installer.runner]]</span><br/>
+        <strong>Draft: </strong><input type="checkbox" disabled checked="[[installer.draft]]"><br/>
+        <strong>Published: </strong><input type="checkbox" disabled checked="[[installer.published]]">
       </p>
       <p>
         <strong>Notes:</strong>

--- a/templates/games/_installer.html
+++ b/templates/games/_installer.html
@@ -62,7 +62,6 @@
   <div class="discreet-text">
     {{ installer.notes|linebreaks }}
   </div>
-  <p class="discreet-text">Created on {{ installer.created_at }}</p>
   <p class="discreet-text">Last updated on {{ installer.updated_at }}</p>
   {% endif %}
 </li>

--- a/templates/games/_installer.html
+++ b/templates/games/_installer.html
@@ -62,5 +62,7 @@
   <div class="discreet-text">
     {{ installer.notes|linebreaks }}
   </div>
+  <p class="discreet-text">Created on {{ installer.created_at }}</p>
+  <p class="discreet-text">Last updated on {{ installer.updated_at }}</p>
   {% endif %}
 </li>


### PR DESCRIPTION
Based on #76, the updated_at field is now shown on the game detail and game review screen.
![](http://rosalilastudio.com:1337/ftp/random/last_up1.png)
![](http://rosalilastudio.com:1337/ftp/random/last_up2.png)