### PR TITLE
Removed Desura references and moved DS

### DIFF
--- a/templates/common/about.html
+++ b/templates/common/about.html
@@ -24,7 +24,7 @@
       <ul>
         <li>Manage your Linux games, Windows games, emulated console games and
         browser games</li>
-        <li>Launch your Steam and Desura games</li>
+        <li>Launch your Steam games</li>
         <li>Community-written installers to ease up your games' installation</li>
         <li>More than 20 emulators installed automatically or in a single
         click, providing support for most gaming systems from the late 70's to
@@ -48,24 +48,24 @@
     <h2>Using Lutris</h2>
     <article>
       <p>
-        Like Steam or Desura, Lutris has two parts: a website and a client
-        application, which communicate. On the website, you can browse the
-        supported games, add them to your personal library and start their
-        installation by clicking on the Install link for the version of the
-        game you possess (if someone bothered to make an installer for it ;).
-        Granted that you have installed the client software, it will open the
-        game installation window, leading you through the steps to finalize the
-        game's setup. Once it's done, you will be able to launch the game
-        directly or close the installation window and the game will be present
-        in your local library the next time you start Lutris.
+        Like Steam, Lutris has two parts: a website and a client application,
+        which communicate. On the website, you can browse the supported games,
+        add them to your personal library and start their installation by
+        clicking on the Install link for the version of the game you possess
+        (if someone bothered to make an installer for it ;). Granted that you
+        have installed the client software, it will open the game installation
+        window, leading you through the steps to finalize the game's setup.
+        Once it's done, you will be able to launch the game directly or close
+        the installation window and the game will be present in your local
+        library the next time you start Lutris.
       </p>
       <p>
         But first you will surely want to use our automated import tool to add
         your existing game libraries. For now we only have import for Steam but
-        in the future Lutris should be able to import your GOG and Desura
-        libraries, your installed ScummVM games, your game roms and maybe scan
-        your system for other installed games. Oh and PlayOnLinux import, we
-        should have it at some point too.
+        in the future Lutris should be able to import your GOG library, your
+        installed ScummVM games, your game roms and maybe scan your system for
+        other installed games. Oh and PlayOnLinux import, we should have it at
+        some point too.
       </p>
       <p>
         To <strong>import your Steam library</strong>, go to your Lutris
@@ -129,7 +129,7 @@
         <li>Magnavox Odyssey², Videopac+</li>
         <li>Mattel Intellivision</li>
         <li>NEC PC-Engine Turbographx 16, Supergraphx, PC-FX</li>
-        <li>Nintendo NES, SNES, Game Boy, Game Boy Advance</li>
+        <li>Nintendo NES, SNES, Game Boy, Game Boy Advance, DS</li>
         <li>Game Cube and Wii</li>
         <li>Sega Master Sytem, Game Gear, Genesis, Dreamcast</li>
         <li>SNK Neo Geo, Neo Geo Pocket</li>
@@ -142,7 +142,6 @@
     <article>
       <p>We have planned support for the following systems:</p>
       <ul>
-        <li>Nintendo DS</li>
         <li>MSX computers</li>
         <li>Sega Saturn</li>
       </ul>


### PR DESCRIPTION
I removed Desura references since it's in hiatus and moved Nintendo DS from planned support to supported since it was implemented since. I think MSX is supported by LibRetro as well, but I left it for the time being - the page may need further updates I might omitted - also related to support of GOG, Humble and possibly Itchio, GameJolt and possibly others.