### PR TITLE
Householding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ public/js
 public/css
 public/fonts
 node_modules
+npm-debug.log
 reports
 ENV
 celerybeat-schedule

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
+env:
+  - DJANGO=1.10.2
+  - DJANGO_SETTINGS_MODULE='lutrisweb.settings.local'
+  - SECRET_KEY="ThisIsMySecretThereAreOtherLikeThisButThisOneIsMine"
 python:
   - 2.7
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 env:
-  - DJANGO=1.10.2
-  - DJANGO_SETTINGS_MODULE='lutrisweb.settings.local'
-  - SECRET_KEY="ThisIsMySecretThereAreOtherLikeThisButThisOneIsMine"
+  - DJANGO=1.10.2 DJANGO_SETTINGS_MODULE='lutrisweb.settings.local' SECRET_KEY="ThisIsMySecretThereAreOtherLikeThisButThisOneIsMine"
 python:
   - 2.7
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - 2.7
+install:
+  - pip install -r config/requirements/devel.pip
+script:
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 env:
-  - DJANGO=1.10.2 DJANGO_SETTINGS_MODULE='lutrisweb.settings.local' SECRET_KEY="ThisIsMySecretThereAreOtherLikeThisButThisOneIsMine"
+  - DJANGO=1.10.2 DJANGO_SETTINGS_MODULE='lutrisweb.settings.local' SECRET_KEY="ThisIsMySecretThereAreOtherLikeThisButThisOneIsMine" USE_SQLITE=1
 python:
   - 2.7
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 setup:
 	npm install
-	bower install --allow-root
-	grunt
+	npm run setup
 run:
 	./manage.py runserver 0.0.0.0:8000
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 setup:
 	npm install
 	npm run setup
+
+watch:
+	npm run watch
+
 run:
 	./manage.py runserver 0.0.0.0:8000
 

--- a/README.rst
+++ b/README.rst
@@ -66,12 +66,7 @@ page ::
 
     https://github.com/creationix/nvm
 
-Then install bower and grunt::
-
-    npm install -g bower
-    npm install -g grunt-cli
-
-Once you have grunt and bower installed, you can run the following commands::
+Once you a recent version of npm installed, you can run the following commands::
 
     make setup  # Will install the project's npm and bower dependencies
                 # and build the static files

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ also tell the project to fallback to SQLite::
 Once your virtualenv is created, you can install the system and python
 dependencies::
 
-    sudo apt-get install imagemagick memcached libmemcached-dev mercurial bzr python-dev
+    sudo apt-get install imagemagick memcached libmemcached-dev libxml2-dev libxslt1-dev mercurial bzr python-dev
     make deps
 
 In order to build the frontend code (javascript and css files), you'll

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ dependencies::
     make deps
 
 In order to build the frontend code (javascript and css files), you'll
-need nodejs, npm, grunt and bower installed on your system. If you are
+need nodejs and npm installed on your system. If you are
 running Ubuntu, it is advised to use nvm to get the most recent
 version of node, you can install it following the instructions on the github
 page ::

--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Once you installed a recent version of npm, you can run the following commands::
 
     make setup  # Will install the project's npm and bower dependencies
                 # and build the static files
-    grunt watch  # Watch for JS/CSS changes and compile them
+    make watch  # Watch for JS/CSS changes and compile them
 
 You'll need to setup the database, if you want to use a PostgreSQL database,
 follow the instructions found in the next paragraph before running this

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ page ::
 
     https://github.com/creationix/nvm
 
-Once you a recent version of npm installed, you can run the following commands::
+Once you installed a recent version of npm, you can run the following commands::
 
     make setup  # Will install the project's npm and bower dependencies
                 # and build the static files

--- a/games/models.py
+++ b/games/models.py
@@ -182,6 +182,31 @@ class Game(models.Model):
         return ("name__icontains",)
 
     @property
+    def website_url(self):
+        """Returns self.website guaranteed to be a valid URI"""
+
+        if not self.website:
+            return None
+        
+        # Fall back to http if no protocol specified (cannot assume that https will work)
+        has_protocol = '://' in self.website
+        return 'http://' + self.website if not has_protocol else self.website
+
+    @property
+    def website_url_hr(self):
+        """Returns a human readable website URL (stripped protocols and trailing slashes)"""
+
+        if not self.website:
+            return None
+        
+        return (
+            self.website
+            .split('https:', 1)[-1]
+            .split('http:', 1)[-1]
+            .strip('/')
+        )
+
+    @property
     def banner_url(self):
         if self.title_logo:
             return reverse('get_banner', kwargs={'slug': self.slug})

--- a/games/tests/test_models.py
+++ b/games/tests/test_models.py
@@ -9,6 +9,69 @@ class TestGame(TestCase):
         self.assertEqual(game.slug, "quake-3-arena")
         self.assertFalse(game.is_public)
 
+    def test_website_url_no_website_specified(self):
+        """
+        Ensures that None is returned for website_url
+        and website_url_hr if no website was specified
+        """
+
+        # Create a game with no website specified
+        game = factories.GameFactory(name='Game Title', website='')
+
+        # website_url should return None
+        self.assertIsNone(game.website_url)
+
+        # website_url_hr should return None
+        self.assertIsNone(game.website_url_hr)
+
+    def test_website_url_no_protocol_specified(self):
+        """Ensures that URLs are uniform if no protocol was specified"""
+
+        # Create a game with a protocol-less website (no http:// or https://)
+        game = factories.GameFactory(name='Game Title', website='example.com')
+
+        # If no protocol was specified, it should fall back to http://
+        self.assertEqual(game.website_url, 'http://example.com')
+
+        # HR URL should be unchanged
+        self.assertEqual(game.website_url_hr, 'example.com')
+
+    def test_website_url_http_specified(self):
+        """Ensures that URLs are uniform if http was specified"""
+
+        # Create a game with an http:// website specified
+        game = factories.GameFactory(name='Game Title', website='http://example.com')
+
+        # If a protocl was specified, it should be returned unchanged
+        self.assertEqual(game.website_url, 'http://example.com')
+
+        # HR URL should strip the http:// part
+        self.assertEqual(game.website_url_hr, 'example.com')
+
+    def test_website_url_https_specified(self):
+        """Ensures that URLs are uniform if https was specified"""
+
+        # Create a game with an https:// website specified
+        game = factories.GameFactory(name='Game Title', website='https://example.com')
+
+        # If a protocl was specified, it should be returned unchanged
+        self.assertEqual(game.website_url, 'https://example.com')
+
+        # HR URL should strip the https:// part
+        self.assertEqual(game.website_url_hr, 'example.com')
+
+    def test_website_url_strip_trailing_slash(self):
+        """Ensures that trailing slashes are stripped for HR website_url"""
+
+        # Create a game with a URL with trailing slash
+        game = factories.GameFactory(name='Game Title', website='http://example.com/')
+
+        # If a trailing slash was given, it should not be stripped for website_url
+        self.assertEqual(game.website_url, 'http://example.com/')
+
+        # HR URL should strip the http:// part and the trailing slash
+        self.assertEqual(game.website_url_hr, 'example.com')
+
     def test_game_list_filters_game_with_no_installers(self):
         doom = factories.GameFactory(name="Doom")
         game_list = models.Game.objects.with_installer()

--- a/games/tests/test_validator.py
+++ b/games/tests/test_validator.py
@@ -15,21 +15,21 @@ class TestScriptValidator(TestCase):
     def test_files_must_not_be_dict(self):
         self.installer.content = json.dumps({'files': {}})
         is_valid, errors = validate_installer(self.installer)
-        self.assertFalse(is_valid)
+        self.assertFalse(is_valid, errors)
 
     def test_files_should_be_list(self):
         self.installer.content = json.dumps({'files': []})
         is_valid, errors = validate_installer(self.installer)
-        self.assertTrue(is_valid)
+        self.assertTrue(is_valid, errors)
 
     def test_scummvm_script_requires_game_id(self):
         script = json.dumps({'game': {}})
         installer = Installer(
-            runner=Runner(name="scummvm"),
+            runner=Runner(name="ScummVM", slug='scummvm'),
             content=script
         )
         is_valid, errors = validate_installer(installer)
-        self.assertFalse(is_valid)
+        self.assertFalse(is_valid, errors)
         self.assertIn("ScummVM game should have a "
                       "game identifier in the 'game' section",
                       errors)

--- a/games/util/installer.py
+++ b/games/util/installer.py
@@ -106,7 +106,7 @@ def winesteam_scripts_use_correct_prefix(installer):
             False,
             "Missing section game"
         )
-    if '$USER' in script['game'].get('prefix'):
+    if '$USER' in script['game'].get('prefix', ''):
         return (
             False,
             "Do not create the prefix in the home folder, use $GAMEDIR/prefix"

--- a/games/util/installer.py
+++ b/games/util/installer.py
@@ -129,3 +129,4 @@ def dont_disable_monitor(installer):
             "Do not disable the process monitor in installers, if you have "
             "issues with the process monitor, submit an issue on Github"
         )
+    return SUCCESS

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -197,7 +197,6 @@ def game_detail(request, slug):
     banner_options = {'crop': 'top', 'blur': '14x6'}
     banner_size = "940x352"
     user = request.user
-    game.website_text = game.website[6:].strip('/')
 
     installers = game.installers.published()
     unpublished_installers = game.installers.unpublished()

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "dependencies": {
   },
   "devDependencies": {
+    "bower": "1.8.2",
     "grunt": "~1.0.1",
+    "grunt-cli": "1.2.0",
     "grunt-browser-sync": "^2.1.3",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
@@ -19,7 +21,8 @@
     "grunt-contrib-watch": "~1.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "setup": "bower install --allow-root && grunt"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "setup": "bower install --allow-root && grunt"
+    "setup": "bower install --allow-root && grunt",
+    "watch": "grunt watch"
   },
   "repository": {
     "type": "git",

--- a/templates/games/detail.html
+++ b/templates/games/detail.html
@@ -65,7 +65,7 @@
           {% if game.website %}
           <li class="ellipse-text">
               <span class="info-label">Website: </span>
-              <a href='{{ game.website }}'>{{ game.website_text }}</a>
+              <a href='{{ game.website_url }}'>{{ game.website_url_hr }}</a>
           </li>
           {% endif %}
         </ul>


### PR DESCRIPTION
Just a few chore-changes 

**TL;DR**

- Don't require `grunt` and `bower` to be global dependencies
- Add `make watch` to substitute `grunt watch`
- Eased instructions in the README
- Ignore node debug files

**Explanations**

Hey, I just wanted to help out and had issues initially setting up the project\*, so I made the setup more comfortable. A few thoughts:

- You are already primary using `make` for the tasking, so you can basically hide everything there. It's super confusing for new people if they have to deal with that much tasking and packaging stuff. I mean, you got package dependencies, bower, grunt, npm, make, ...
- Using the `scripts` part of the `package.json` is very comfortable to define scripts and tasks, since it adds `node_modules/bin` to its path. No need to install anything globally
- By not having global node deps, you can specifically set the versions so no dev will have issues with weird version incompatibilities 

**\* The issues I had**
The `bower` command was not available, so it crashed when running `make setup`, even though I could run `bower` in the very same terminal without `make` in between.