### PR TITLE
Improve mobile UX

### DIFF
--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -232,6 +232,8 @@ input {
 }
 
 .pagination-block-wrapper {
+  margin-top: 20px;
+
   .pagination-block {
     display: table;
     margin: 0 auto;
@@ -240,7 +242,8 @@ input {
       list-style: none;
       padding: 0;
       margin: 0;
-      background-color: #444;
+      background-color: #222;
+      border-radius: 4px;
 
       li {
         position: relative;
@@ -250,14 +253,15 @@ input {
       li a,
       li span {
         display: inline-block;
-        color: #DDD;
+        color: #AEAEAE;
         margin: 0;
         padding: 10px 15px;
       }
 
-      li a:hover {
+      li a:hover,
+      li a:focus {
         text-decoration: none;
-        background-color: #666;
+        color: #fff;
       }
     }
   }

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -630,6 +630,42 @@ input {
   }
 }
 
+.subnav {
+  .clearfix;
+
+  & > ul.breadcrumb,
+  & > button {
+    height: 39px;
+  }
+
+  & > ul.breadcrumb {
+    float: left;
+    width: calc(100% - 43px); /* Full width minux button width minux 5px margin */
+
+    @media (min-width: @screen-sm-min) {
+      width: 100%;
+    }
+  }
+
+  & > button {
+    width: 38px;
+    border: none;
+    color: #AEAEAE;
+    background: none;
+    background-color: #222;
+    float: right;
+    border-radius: 4px;
+
+    @media (min-width: @screen-sm-min) {
+      display: none;
+    }
+  }
+
+  & > button:hover {
+    color: white;
+  }
+}
+
 .breadcrumb {
   margin: 0 0 20px;
   list-style: none;
@@ -692,6 +728,14 @@ input {
   & > .active {
     color: #999999;
   }
+}
+
+#filter-mobile {
+  background-color: #444;
+  color: #DDD;
+  padding: 10px;
+  margin: 0;
+  margin-bottom: 20px;
 }
 
 .footnote {
@@ -1302,15 +1346,19 @@ input {
 
 
 .filter-list {
+  display: inline-block;
   .ul-reset;
   list-style-position: inside;
   margin: 0;
+
   li {
-    margin: 5px 0px;
+    display: inline-block;
+    margin: 0px;
+    margin-top: 5px;
   }
+
   a {
     display: block;
-    padding-left: 15px;
   }
 }
 
@@ -1319,10 +1367,15 @@ input {
   font-size: .75em;
   text-transform: uppercase;
   vertical-align: text-top;
-  padding: 3px 6px;
+  padding: 6px 12px;
   color: #EDEDED;
   border-radius: 2px;
   white-space: nowrap;
+
+  @media (min-width: @screen-sm-min) {
+    padding: 3px 6px;
+  }
+
   &:hover {
     background-color: #666;
     color: inherit;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -231,16 +231,35 @@ input {
   }
 }
 
-.pagination-block {
-  font-size: .85em;
-  a {
-    color: #AAA;
-  }
-  .pagination-pager {
-    float: right;
-  }
-  .pagination-info {
-    float: left;
+.pagination-block-wrapper {
+  .pagination-block {
+    display: table;
+    margin: 0 auto;
+
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      background-color: #444;
+  
+      li {
+        position: relative;
+        float: left;
+      }
+  
+      li a,
+      li span {
+        display: inline-block;
+        color: #DDD;
+        margin: 0;
+        padding: 10px 15px;
+      }
+
+      li a:hover {
+        text-decoration: none;
+        background-color: #666;
+      }
+    }
   }
 }
 
@@ -1098,7 +1117,7 @@ input {
 
 .game-cover {
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
-  margin-bottom: 5px;
+  margin-bottom: 0;
   display: block;
   width: 184px;
   height: 69px;
@@ -1109,6 +1128,10 @@ input {
   color: #AAA;
   font-size: 1.5em;
   position: relative;
+
+  @media (min-width: @screen-sm-min) {
+    margin-bottom: 5px;
+  }
 }
 
 .game-banner {

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -50,6 +50,7 @@ article {
       font-size: 1.2em;
   }
 }
+
 h1, h2, h3, h4, h5 {
   font-weight: normal;
   word-spacing: .1em;
@@ -62,9 +63,21 @@ h1 {
   font-weight: 300;
   box-shadow: 0px 4px 1px -2px rgba(0,0,0,.3);
   padding: 3px;
+  padding-left: 15px;
+
+  font-size: 1.6em;
+  margin-top: 10px;
+
+  @media (min-width: @screen-sm-min) {
+    font-size: 2em;
+    margin-top: 20px;
+  }
 }
 
-h2 { font-size: 1.4em; }
+h2 {
+  font-size: 1.4em;
+}
+
 h3 {
   color: #BBB;
   font-size: 1.2em;
@@ -72,6 +85,7 @@ h3 {
   padding: 7px 14px;
   font-weight: 300;
 }
+
 h4 {
   font-size: 1.1em;
   color: #CDCDCD;
@@ -168,6 +182,8 @@ input {
 
 .container {
   .container-fixed();
+  padding-left: 0;
+  padding-right: 0;
 
   @media (min-width: @screen-sm-min) {
     width: @container-sm;
@@ -327,7 +343,6 @@ input {
 .navbar {
   box-shadow: 0 0 10px #000;
   font-weight: 300;
-  min-height: 84px;
   margin: auto;
   font-family: @sansSerif;
   .brand {
@@ -347,8 +362,13 @@ input {
     }
   }
   .logo {
-    width: 64px;
-    height: 64px;
+    width: 34px;
+    height: 34px;
+
+    @media (min-width: @screen-md-min) {
+      width: 64px;
+      height: 64px;
+    }
   }
   .nav > li > a {
     color: #aaa;
@@ -996,9 +1016,13 @@ input {
   li {
     border-bottom: 2px solid #252525;
     color: #999;
-    padding: 8px;
+    padding: 0;
     margin-bottom: 5px;
     background-color: @darkerBackground;
+
+    @media (min-width: @screen-sm-min) {
+      padding: 8px;
+    }
   }
   a {
     color :#DDD;
@@ -1015,8 +1039,16 @@ input {
   }
   .game-cover {
     float: left;
-    margin-right: 15px;
+    margin-right: 0;
+    width: 100%;
+    height: auto;
     overflow: hidden;
+
+    @media (min-width: @screen-sm-min) {
+      margin-right: 15px;
+      width: 184px;
+      height: 69px;
+    }
   }
   .game-title {
     font-size: 1.1em;
@@ -1083,10 +1115,14 @@ input {
 }
 
 .pane {
-  padding: 0px 14px;
+  padding: 0px;
   p {
     margin-top: 15px;
     color: #ACACAC;
+  }
+
+  @media (min-width: @screen-sm-min) {
+    padding: 0px 14px;
   }
 }
 

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -642,10 +642,14 @@ input {
   white-space: nowrap;
 
   li {
-    /* float: left; */
     position: relative;
     text-shadow: 0 1px 0 #ffffff;
     display: inline;
+    padding-left: 0;
+
+    &:before {
+      content: "" !important;
+    }
 
     a {
       text-shadow: none;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -559,27 +559,49 @@ input {
 
 .download-list {
   padding: 0;
+
   li {
     list-style-type: none;
   }
+
   &>li {
-    padding: 15px 20px;
+    padding: 14px 15px;
     border-bottom: 1px solid #555;
+
+    @media (min-width: @screen-sm-min) {
+      padding: 15px 20px;
+    }
+
     &:last-child {
       border-bottom: none;
     }
+
     ul {
       width: 200px;
-      border-right: 1px solid #444;
-      display: table-cell;
+      padding-left: 0;
+      border-right: none;
+      display: block;
+
+      @media (min-width: @screen-sm-min) {
+        padding-left: 35px;
+        display: table-cell;
+        border-right: 1px solid #444;
+      }
     }
+
     p {
-      display: table-cell;
-      padding: 7px 34px;
+      display: block;
+      padding: 7px 0 7px 34px;
       font-size: .9em;
       color: #AEAEAE;
+
+      @media (min-width: @screen-sm-min) {
+        padding: 7px 34px;
+        display: table-cell;
+      }
     }
   }
+
   img {
     margin: 7px;
   }

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -635,14 +635,23 @@ input {
   list-style: none;
   background-color: #222;
   overflow: hidden;
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
   li {
-    float: left;
+    /* float: left; */
     position: relative;
     text-shadow: 0 1px 0 #ffffff;
+    display: inline;
+
     a {
       text-shadow: none;
       padding: 8px 0px 8px 50px;
       color: #AEAEAE;
+
       &:before, &:after {
         content: " ";
         display: block;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -389,13 +389,21 @@ input {
     }
   }
 
-  #search-games > .search-games-content {
-    padding-top: 5px;
-    padding-bottom: 5px;
+  #search-games {
+    display: block;
 
-    input[type="text"] {
-      background: none;
-      border: none;
+    @media (min-width: @screen-sm-min) {
+      display: none;
+    }
+
+    .search-games-content {
+      padding-top: 5px;
+      padding-bottom: 5px;
+  
+      input[type="text"] {
+        background: none;
+        border: none;
+      }
     }
   }
 
@@ -778,6 +786,10 @@ input {
       background-color: #444;
       color: #DDD;
       padding: 10px;
+
+      .input-group{
+        width: 100%
+      }
     }
   }
 }
@@ -1266,14 +1278,11 @@ input {
 }
 
 .pane {
-  padding: 0px;
+  padding: 0;
+
   p {
     margin-top: 15px;
     color: #ACACAC;
-  }
-
-  @media (min-width: @screen-sm-min) {
-    padding: 0px 14px;
   }
 }
 

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -668,11 +668,11 @@ input {
 
 .breadcrumb {
   margin: 0 0 20px;
+  padding: 8px 10px;
   list-style: none;
   background-color: #222;
   overflow: hidden;
   display: inline-block;
-  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -689,7 +689,7 @@ input {
 
     a {
       text-shadow: none;
-      padding: 8px 0px 8px 50px;
+      padding: 8px 0px 8px 35px;
       color: #AEAEAE;
 
       &:before, &:after {

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -407,6 +407,7 @@ input {
     color: #aaa;
   }
 
+  .navbar-header > button:hover,
   .navbar-header > button:active,
   .navbar-header > button:focus {
     color: #fff;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -730,12 +730,15 @@ input {
   }
 }
 
-#filter-mobile {
-  background-color: #444;
-  color: #DDD;
-  padding: 10px;
+.filter-mobile-content {
   margin: 0;
   margin-bottom: 20px;
+
+  .pane {
+    background-color: #444;
+    color: #DDD;
+    padding: 10px;
+  }
 }
 
 .footnote {

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -986,6 +986,7 @@ input {
     margin: 0 auto;
     display: block;
     margin-bottom: 14px;
+    width: 100%;
   }
 
   ul {

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -258,6 +258,8 @@ input {
         padding: 10px 15px;
       }
 
+      li a:hover span,
+      li a:focus span,
       li a:hover,
       li a:focus {
         text-decoration: none;
@@ -390,11 +392,11 @@ input {
   }
 
   #search-games {
-    /* display: block;
+    /* display: block;*/
 
     @media (min-width: @screen-sm-min) {
-      display: none;
-    } */
+      display: none !important;
+    } 
 
     .search-games-content {
       padding-top: 5px;
@@ -788,7 +790,7 @@ input {
       padding: 10px;
 
       .input-group{
-        width: 100%
+        width: 100%;
       }
     }
   }

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -59,11 +59,16 @@ article {
     right: 7px; /* 15px padding like h1 on the left - 8px padding of a to span */
     bottom: 2px;
 
+    @media (min-width: @screen-sm-min) {
+      display: none;
+    }
+
     a {
       background: none;
       border: none;
       margin: 0;
       padding: 4px 8px;
+      color: #aaa;
     }
   }
 }

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -51,6 +51,23 @@ article {
   }
 }
 
+.header-wrap {
+  position: relative;
+
+  .header-control {
+    position: absolute;
+    right: 7px; /* 15px padding like h1 on the left - 8px padding of a to span */
+    bottom: 2px;
+
+    a {
+      background: none;
+      border: none;
+      margin: 0;
+      padding: 4px 8px;
+    }
+  }
+}
+
 h1, h2, h3, h4, h5 {
   font-weight: normal;
   word-spacing: .1em;
@@ -713,48 +730,10 @@ input {
   }
 }
 
-.subnav {
-  .clearfix;
-
-  & > ul.breadcrumb,
-  & > button {
-    height: 39px;
-  }
-
-  & > ul.breadcrumb {
-    float: left;
-    width: calc(100% - 43px); /* Full width minus button width minus 5px margin */
-
-    @media (min-width: @screen-sm-min) {
-      width: 100%;
-    }
-  }
-
-  & > button {
-    width: 38px;
-    border: none;
-    color: #AEAEAE;
-    background: none;
-    background-color: #222;
-    float: right;
-    border-radius: 4px;
-
-    @media (min-width: @screen-sm-min) {
-      display: none;
-    }
-  }
-
-  & > button:focus,
-  & > button:active,
-  & > button:hover {
-    color: white;
-    background-color: #222;
-  }
-}
-
 .breadcrumb {
-  margin: 0 0 20px;
+  margin: 0 0 20px 0;
   padding: 8px 10px;
+  width: 100%;
   list-style: none;
   background-color: #222;
   overflow: hidden;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -375,6 +375,8 @@ input {
     color: #ccc;
     padding: 10px;
     font-size: 2.2em;
+    position: relative;
+    z-index: 100;
 
     img {
       display: inline-block;
@@ -399,7 +401,7 @@ input {
         position: absolute;
         top: 0;
         bottom: 0;
-        left: 60px;
+        left: 0;
         right: 48px;
         margin: 0;
         padding: 0;
@@ -414,8 +416,6 @@ input {
       }
 
       @media (min-width: @screen-md-min) {
-        left: 300px;
-
         .search-games-content {
           padding-top: 47px;
         }

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -636,7 +636,7 @@ input {
   background-color: #222;
   overflow: hidden;
   display: inline-block;
-  max-width: 100%;
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -640,7 +640,7 @@ input {
 
   & > ul.breadcrumb {
     float: left;
-    width: calc(100% - 43px); /* Full width minux button width minux 5px margin */
+    width: calc(100% - 43px); /* Full width minus button width minus 5px margin */
 
     @media (min-width: @screen-sm-min) {
       width: 100%;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -392,19 +392,60 @@ input {
   }
 
   #search-games {
-    /* display: block;*/
+    &.collapsing,
+    &.collapse.in {
+      @media (min-width: @screen-sm-min) {
+        display: block !important;
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 60px;
+        right: 48px;
+        margin: 0;
+        padding: 0;
+        background-color: #222;
+        z-index: 10;
+        text-align: right;
 
-    @media (min-width: @screen-sm-min) {
-      display: none !important;
-    } 
+        .search-games-content {
+          padding-right: 15px;
+          padding-top: 9px;
+        }
+      }
+
+      @media (min-width: @screen-md-min) {
+        left: 300px;
+
+        .search-games-content {
+          padding-top: 47px;
+        }
+      }
+
+      @media (min-width: @screen-lg-min) {
+        right: 58px;
+      }
+    }
+
+    &.collapse {
+      @media (min-width: @screen-sm-min) {
+        display: none !important;
+      }
+    }
 
     .search-games-content {
       padding-top: 5px;
       padding-bottom: 5px;
-  
+
+      @media (min-width: @screen-sm-min) {
+        padding: 5px;
+      }
+
       input[type="text"] {
+        color: #aaa;
         background: none;
         border: none;
+        box-shadow: none;
+        outline: 0;
       }
     }
   }
@@ -783,7 +824,7 @@ input {
   .filter-controls-content {
     margin: 0;
     margin-bottom: 20px;
-  
+
     .pane {
       background-color: #444;
       color: #DDD;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -389,6 +389,16 @@ input {
     }
   }
 
+  #search-games > .search-games-content {
+    padding-top: 5px;
+    padding-bottom: 5px;
+
+    input[type="text"] {
+      background: none;
+      border: none;
+    }
+  }
+
   .logo {
     width: 34px;
     height: 34px;
@@ -755,14 +765,20 @@ input {
   }
 }
 
-.filter-mobile-content {
-  margin: 0;
-  margin-bottom: 20px;
+#filter-controls {
+  @media (min-width: @screen-sm-min) {
+    display: block !important; /* Controls should always be visible on large screens */
+  }
 
-  .pane {
-    background-color: #444;
-    color: #DDD;
-    padding: 10px;
+  .filter-controls-content {
+    margin: 0;
+    margin-bottom: 20px;
+  
+    .pane {
+      background-color: #444;
+      color: #DDD;
+      padding: 10px;
+    }
   }
 }
 

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -1188,6 +1188,8 @@ input {
 
 .game-filter {
   float: right;
+  margin-bottom: 20px;
+
   input {
     background-color: #444;
     color: #CCC;
@@ -1483,16 +1485,23 @@ input {
     position: relative;
     top: 0px;
     float: right;
+    
     .help {
       position: absolute;
       white-space:nowrap;
-      top: -5px;
-      right: 7px;
+      top: 0;
+      right: 0;
       font-size: .9em;
       background-color: #4c4c4c;
       padding: 3px 7px;
       border-radius: 2px;
       color: #333;
+
+      @media (min-width: @screen-sm-min) {
+        top: -5px;
+        right: -5px;
+      }
+
       &:hover {
         background-color: #777;
         color: #DEDEDE;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -390,11 +390,11 @@ input {
   }
 
   #search-games {
-    display: block;
+    /* display: block;
 
     @media (min-width: @screen-sm-min) {
       display: none;
-    }
+    } */
 
     .search-games-content {
       padding-top: 5px;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -368,22 +368,27 @@ input {
   font-weight: 300;
   margin: auto;
   font-family: @sansSerif;
+
   .brand {
     color: #ccc;
     padding: 10px;
     font-size: 2.2em;
+
     img {
       display: inline-block;
     }
+
     p {
       vertical-align: middle;
       display: inline-block;
       margin-bottom: 0px;
     }
+
     span {
       font-size: .5em;
     }
   }
+
   .logo {
     width: 34px;
     height: 34px;
@@ -393,6 +398,20 @@ input {
       height: 64px;
     }
   }
+
+  .navbar-header > button {
+    background: none;
+    border: none;
+    margin-right: 5px;
+    margin-bottom: 0;
+    color: #aaa;
+  }
+
+  .navbar-header > button:active,
+  .navbar-header > button:focus {
+    color: #fff;
+  }
+
   .nav > li > a {
     color: #aaa;
 
@@ -417,6 +436,7 @@ input {
     text-transform: uppercase;
     font-size: .8em;
     font-weight: 400;
+
     &:hover {
       color: #ccc;
       background-color: #555;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -411,6 +411,7 @@ input {
   .navbar-header > button:active,
   .navbar-header > button:focus {
     color: #fff;
+    background: none;
   }
 
   .nav > li > a {
@@ -682,8 +683,11 @@ input {
     }
   }
 
+  & > button:focus,
+  & > button:active,
   & > button:hover {
     color: white;
+    background-color: #222;
   }
 }
 

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -241,12 +241,12 @@ input {
       padding: 0;
       margin: 0;
       background-color: #444;
-  
+
       li {
         position: relative;
         float: left;
       }
-  
+
       li a,
       li span {
         display: inline-block;

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -36,7 +36,7 @@ LOGGER = logging.getLogger(__name__)
 class GameList(ListView):
     model = models.Game
     context_object_name = "games"
-    paginate_by = 25
+    paginate_by = 5
 
     def get_queryset(self):
         unpublished_filter = self.request.GET.get('unpublished-filter')

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -36,7 +36,7 @@ LOGGER = logging.getLogger(__name__)
 class GameList(ListView):
     model = models.Game
     context_object_name = "games"
-    paginate_by = 5
+    paginate_by = 25
 
     def get_queryset(self):
         unpublished_filter = self.request.GET.get('unpublished-filter')

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -92,6 +92,7 @@ class GameList(ListView):
         page = context['page_obj']
         paginator = page.paginator
         page_indexes = get_page_range(paginator.num_pages, page.number)
+        page.page_count = page_indexes[-1]
         pages = []
         for i in page_indexes:
             if i:

--- a/templates/accounts/library_show.html
+++ b/templates/accounts/library_show.html
@@ -5,13 +5,13 @@
 
 
 {% block content %}
+<h1>Library <small>{{ games.count }} Games</small></h1>
 <div class="row">
   <div class="col-md-12">
     <div class="game-list-header">
       <h2>Your games</h2>
-      <span class="centered">{{ games.count }} games in library</span>
       <form class="game-filter">
-        <input type="text" placeholder="filter games" id="game-filter"/>
+        <input type="text" placeholder="Filter your games…" id="game-filter"/>
       </form>
     </div>
     <ul class="game-list user-library">

--- a/templates/accounts/library_show.html
+++ b/templates/accounts/library_show.html
@@ -5,15 +5,20 @@
 
 
 {% block content %}
+
+<!-- HEADER -->
 <h1>Library <small>{{ games.count }} Games</small></h1>
+
 <div class="row">
   <div class="col-md-12">
-    <div class="game-list-header">
-      <h2>Your games</h2>
-      <form class="game-filter">
-        <input type="text" placeholder="Filter your games…" id="game-filter"/>
-      </form>
-    </div>
+    <form class="game-filter">
+      <input type="text" placeholder="Filter your games…" id="game-filter" />
+    </form>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
     <ul class="game-list user-library">
       {% for game in games %}
         {% include "includes/game_preview.html" %}

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -6,6 +6,7 @@
 
 
 {% block content %}
+<h1>Account</h1>
 <div class="row">
   <div class="col-md-12">
   <div class="profile-header">

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,11 +32,14 @@
     <nav class="navbar navbar-default navbar-inverse">
       <div class="container-fluid">
         <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+              data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
+            <span class="glyphicon glyphicon-menu-hamburger" aria-hidden="true"></span>
+          </button>
+          <button type="button" class="navbar-toggle">
+            <span class="sr-only">Search games</span>
+            <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
           </button>
           <a class="navbar-brand brand" href='/'>
             <img class='logo' src='{{ STATIC_URL }}images/logo-big.png' alt='Lutris'/>

--- a/templates/base.html
+++ b/templates/base.html
@@ -41,7 +41,7 @@
             <span class="sr-only">Toggle navigation</span>
             <span class="glyphicon glyphicon-menu-hamburger" aria-hidden="true"></span>
           </button>
-          
+
           <!-- SEARCH GAME BUTTON -->
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
               data-target="#search-games" aria-expanded="false" aria-controls="navbar">
@@ -63,7 +63,7 @@
           <div class="search-games-content">
             <form action="{% url 'game_list' %}" method="get" class="form-inline">
               <div class="input-group">
-                <input type="text" name="q" class="search-query form-control" 
+                <input type="text" name="q" class="search-query form-control"
                     placeholder="Search…" />
                 <span class="input-group-btn">
                   <button class="btn btn-default" type="submit">Search</button>
@@ -82,12 +82,19 @@
             <li><a href="https://forums.lutris.net">Forums</a></li>
             {% if user.is_authenticated %}
               <li><a href="{% url 'library_show' user.username %}">My Library</a></li>
-              <li><a href="{% url 'user_account' user.username %}">My account</a></li>
+              <li><a href="{% url 'user_account' user.username %}">My Account</a></li>
               <li><a href="{% url 'logout' %}">Logout</a></li>
             {% else %}
               <li><a href="{% url 'login' %}">Login</a></li>
               <li><a href="{% url 'register' %}">Register</a></li>
             {% endif %}
+            <li class="hidden-xs">
+              <a href="#" class="collapsed" data-toggle="collapse"
+                  data-target="#search-games" aria-expanded="false" aria-controls="navbar">
+                <span class="sr-only">Search games</span>
+                <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+            </a>
+            </li>
           </ul>
         </div>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -113,7 +113,8 @@
             <h5>Support us!</h5>
             <p>
               <a href="https://patreon.com/lutris">
-                <img src="{% static 'images/patreon_white.png' %}" alt="Support Lutris on Patreon" />
+                <img src="{% static 'images/patreon_white.png' %}" alt="Support Lutris on Patreon"
+                    style="width: 100%; max-width: 240px;" />
               </a>
             </p>
           </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -40,7 +40,7 @@
           </button>
           <a class="navbar-brand brand" href='/'>
             <img class='logo' src='{{ STATIC_URL }}images/logo-big.png' alt='Lutris'/>
-            <p>
+            <p class="hidden-sm hidden-xs">
               Lutris<br/><span>Open Gaming Platform</span>
             </p>
           </a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,9 @@
   <meta name="description" content="Lutris is a gaming platform for Linux. It supports as many games as possible for a wide variety of platforms (native games, Windows, Playstation, Gamecube, SNES, Arcade games, Amiga, etc ...). "/>
   <meta name="keywords" content="Lutris, Linux, GNU / Linux, gaming, video games, native, humble bundle, loki, windows games, nintendo, sega, playstation, dos, amiga, atari, neo geo, pc engine, joypad, joystick, python, open source, free software, gpl, steam, desura" />
   <link rel="shortcut icon" href="{{ STATIC_URL }}favicon.ico" />
-  <link rel="publisher" href="https://plus.google.com/+LutrisNet">
-  <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700,800,900' rel='stylesheet' type='text/css'>
+  <link rel="publisher" href="https://plus.google.com/+LutrisNet" />
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,600,700,800,900"
+      rel="stylesheet" type="text/css" />
   <link type="text/css" href="{{ STATIC_URL }}css/libs.min.css" rel="stylesheet" />
   <link type="text/css" href="{{ STATIC_URL }}css/lutris.min.css" rel="stylesheet" />
   {% block stylesheets %}{% endblock %}
@@ -20,50 +21,76 @@
 <body>
   {% if messages %}
   <ul class="alerts">
-      {% for message in messages %}
+    {% for message in messages %}
       <li{% if message.tags %} class="alert alert-dismissable alert-{{ message.tags }}"{% endif %}>
         {{ message }}
         <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
       </li>
-      {% endfor %}
+    {% endfor %}
   </ul>
   {% endif %}
   <div class="container">
     <nav class="navbar navbar-default navbar-inverse">
       <div class="container-fluid">
+
+        <!-- NAV ICONS + BRAND -->
         <div class="navbar-header">
+          <!-- MENU BUTTON -->
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
               data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
             <span class="glyphicon glyphicon-menu-hamburger" aria-hidden="true"></span>
           </button>
-          <button type="button" class="navbar-toggle">
+          
+          <!-- SEARCH GAME BUTTON -->
+          <button type="button" class="navbar-toggle collapsed" data-toggle="collapse"
+              data-target="#search-games" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Search games</span>
             <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
           </button>
-          <a class="navbar-brand brand" href='/'>
-            <img class='logo' src='{{ STATIC_URL }}images/logo-big.png' alt='Lutris'/>
+
+          <!-- BRAND -->
+          <a class="navbar-brand brand" href="/">
+            <img class="logo" src="{{ STATIC_URL }}images/logo-big.png" alt="Lutris" />
             <p class="hidden-sm hidden-xs">
               Lutris<br/><span>Open Gaming Platform</span>
             </p>
           </a>
         </div>
+
+        <!-- SEARCH GAME COLLAPSE -->
+        <div id="search-games" class="navbar-collapse collapse">
+          <div class="search-games-content">
+            <form action="{% url 'game_list' %}" method="get" class="form-inline">
+              <div class="input-group">
+                <input type="text" name="q" class="search-query form-control" 
+                    placeholder="Search…" />
+                <span class="input-group-btn">
+                  <button class="btn btn-default" type="submit">Search</button>
+                </span>
+              </div>
+            </form>
+          </div>
+        </div>
+
+        <!-- MENU COLLAPSE -->
         <div id="navbar" class="navbar-collapse collapse">
-          <ul class="nav navbar-nav navbar-right" id='main-nav'>
-            <li><a href='{% url "about" %}'>About</a></li>
-            <li><a href='{% url "downloads" %}'>Download</a></li>
-            <li><a href="{% url "game_list" %}">Games</a></li>
+          <ul class="nav navbar-nav navbar-right" id="main-nav">
+            <li><a href="{% url 'about' %}">About</a></li>
+            <li><a href="{% url 'downloads' %}">Download</a></li>
+            <li><a href="{% url 'game_list' %}">Games</a></li>
             <li><a href="https://forums.lutris.net">Forums</a></li>
             {% if user.is_authenticated %}
-              <li><a href="{% url "library_show" user.username %}">My Library</a></li>
-              <li><a href="{% url "user_account" user.username %}">My account</a></li>
-              <li><a href="{% url "logout" %}">Logout</a></li>
+              <li><a href="{% url 'library_show' user.username %}">My Library</a></li>
+              <li><a href="{% url 'user_account' user.username %}">My account</a></li>
+              <li><a href="{% url 'logout' %}">Logout</a></li>
             {% else %}
-              <li><a href="{% url "login" %}">Login</a></li>
-              <li><a href="{% url "register" %}">Register</a></li>
+              <li><a href="{% url 'login' %}">Login</a></li>
+              <li><a href="{% url 'register' %}">Register</a></li>
             {% endif %}
           </ul>
         </div>
+
       </div>
     </nav>
 

--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -27,7 +27,7 @@
         </ul>
         <p>
           Packages compatible with Debian and Ubuntu are available on the
-          <a href="https://build.opensuse.org/package/binaries/home:strycore/lutris?repository=Debian_8.0">openSUSE build service</a>
+          <a href="https://build.opensuse.org/package/binaries/home:strycore/lutris?repository=Debian_8.0">openSUSE build service</a>.
           <br/>
           You can add a repository to receive automatic updates:<br/>
           <br/>
@@ -57,7 +57,7 @@
         <p>
           Packages and repositories for current versions of Fedora and openSUSE
           are available from the
-          <a href="https://software.opensuse.org/download.html?project=home%3Astrycore&package=lutris">openSUSE Build Service</a>
+          <a href="https://software.opensuse.org/download.html?project=home%3Astrycore&package=lutris">openSUSE Build Service</a>.
         </p>
       </li>
       <li>

--- a/templates/games/detail.html
+++ b/templates/games/detail.html
@@ -24,7 +24,7 @@
   <div class="row">
     <div class="col-md-3 col-md-push-9">
       <div class="game-info">
-        {% thumbnail game.title_logo "184" as img %}
+        {% thumbnail game.title_logo "300" as img %}
           <img src="{{ img.url }}" class="banner" />
         {% endthumbnail %}
         <ul>

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -10,7 +10,7 @@
   <!-- FILTER CONTROLS -->
   <div class="col-sm-4 col-lg-3 col-sm-push-8 col-lg-push-9 collapse" id="filter-controls">
     <a href="{% url 'game-submit' %}" class="main-button margin-auto hidden-xs"
-        style="margin-bottom: 20px;">Submit a new game</a>
+        style="margin-top: 2px; margin-bottom: 22px; height: 35px;">Submit a new game</a>
     <div class="filter-controls-content">
       <div class="pane">
             

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -68,7 +68,7 @@
     </div>
   </div>
 </div>
-  <div class="col-sm-4 col-lg-3">
+  <div class="col-sm-4 col-lg-3 hidden-xs">
     <div class="pane">
       <a href="{% url "game-submit" %}" class="main-button margin-auto">Submit a new game</a>
       <h4>Search games</h4>

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -135,6 +135,11 @@
             data-target="#filter-controls" aria-expanded="false" aria-controls="filter-controls">
           <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
         </button>
+
+        <button type="button" class="btn btn-default" data-toggle="collapse" onclick="blur();"
+            data-target="#filter-controls" aria-expanded="false" aria-controls="filter-controls">
+          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+        </button>
       </div>
 
       <!-- GAME LIST -->
@@ -143,12 +148,16 @@
           {% include "includes/game_preview.html" %}
         {% endfor %}
         {% if not games %}
-          <em>
-            No games found that match these criteria.
-            {% if not unpublished_filter %}
-              However, <a href="{% append_to_get unpublished-filter='on' %}">{{ unpublished_match_count }} unpublished games</a> do.
-            {% endif %}
-          </em>
+          <p><em>No games found that match these criteria.</em></p>
+          {% if not unpublished_filter and unpublished_match_count > 0 %}
+            <p>
+              <em>However, <a href="{% append_to_get unpublished-filter='on' %}">{{ unpublished_match_count }} unpublished games</a> do.</em>
+            </p>
+          {% else %}
+            <p>
+              <em>Feel free to <a href="{% url 'game-submit' %}">add the game</a> to our database.</em>
+            </p>
+          {% endif %}
         {% endif %}
       </ul>
 

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -156,7 +156,7 @@
             <ul class="pagination-block clearfix">
               {% if page_obj.number == 1 %}
               <li><a href="{% append_to_get page=page_obj.next_page_number %}">
-                Next<span style="width: 20px;"></span>&rsaquo;
+                  <span style="margin: 0; padding: 0; padding-right: 30px;">Next</span>&rsaquo;
               </a></li>
               {% else %}
                 {% if page_obj.number >= 3 %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -42,6 +42,9 @@
       {% for game in games %}
         {% include "includes/game_preview.html" %}
       {% endfor %}
+      {% if not games %}
+        <em>No games found that match these criteria.</em>
+      {% endif %}
     </ul>
 
     {% if page_obj.page_count > 1 %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -10,26 +10,26 @@
     <div class="pane">
     <ul class='breadcrumb'>
       <li>
-        <a href='/games'>All</a>
+        <a href="/games">All</a>
       </li>
       {% if genre %}
         <li>
-          <a href='{% url "games_by_genre" genre.slug %}'>{{ genre }}</a>
+          <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
         </li>
       {% endif %}
       {% if platform %}
       <li>
-        <a href='/games/platform/{{ platform.slug }}'>{{ platform }}</a>
+        <a href="/games/platform/{{ platform.slug }}">{{ platform }}</a>
       </li>
       {% endif %}
       {% if year %}
       <li>
-        <a href='{% url "games_by_year" year %}'>{{ year }}</a>
+        <a href="{% url 'games_by_year' year %}">{{ year }}</a>
       </li>
       {% endif %}
       {% if company %}
       <li>
-        <a href='{% url "games_by_company" company.slug %}'>{{ company.name }}</a>
+        <a href="{% url 'games_by_company' company.slug %}">{{ company.name }}</a>
       </li>
       {% endif %}
       {% if search_terms %}
@@ -38,7 +38,7 @@
       {% endif %}
     </ul>
 
-    <ul class='game-list'>
+    <ul class="game-list">
       {% for game in games %}
         {% include "includes/game_preview.html" %}
       {% endfor %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -44,26 +44,29 @@
       {% endfor %}
     </ul>
 
-    <div class="pagination-block">
-      <div class="pagination-pager">
-        {% if page_obj.has_previous %}
-          <a href="{% append_to_get page=page_obj.previous_page_number %}">&laquo;</a>
-        {% endif %}
-        {% for page in page_range %}
-          {% if not page %}
-          …
-          {% elif page.number == page_obj.number %}
-            {{ page.number }}
+    <div class="pagination-block-wrapper">
+      <div class="pagination-block">
+        <ul class="pagination-block clearfix">
+          {% if page_obj.number == 1 %}
+          <li><a href="{% append_to_get page=page_obj.next_page_number %}">
+            Next<span style="width: 20px;"></span>&rsaquo;
+          </a></li>
           {% else %}
-            <a href="{% append_to_get page=page.number %}">{{ page.number }}</a>
+            {% if page_obj.number >= 3 %}
+              <li><a href="{% append_to_get page=1 %}">&laquo;</a></li>
+            {% endif %}
+
+            {% if page_obj.number >= 2 %}
+              <li><a href="{% append_to_get page=page_obj.previous_page_number %}">&lsaquo;</a></li>
+            {% endif %}
+
+            <li><span>Page {{ page_obj.number }}</span></li>
+
+            {% if page_obj.has_next %}
+              <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
+            {% endif %}
           {% endif %}
-        {% endfor %}
-        {% if page_obj.has_next %}
-            <a href="{% append_to_get page=page_obj.next_page_number %}">&raquo;</a>
-        {% endif %}
-      </div>
-      <div class='pagination-info'>
-        {{ page_obj.start_index }}-{{ page_obj.end_index}} of {{ page_obj.paginator.count }}
+        </ul>
       </div>
     </div>
   </div>

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -8,45 +8,124 @@
 <div class="row">
   <div class="col-sm-8 col-lg-9">
     <div class="pane">
-      <ul class='breadcrumb'>
-        <li>
-          <a href="/games">All</a>
-        </li>
-        {% if genre %}
+      <div class="subnav">
+        <ul class='breadcrumb'>
           <li>
-            <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
+            <a href="/games">All</a>
           </li>
-        {% endif %}
-        {% if platform %}
-          <li>
-            <a href="/games/platform/{{ platform.slug }}">{{ platform }}</a>
-          </li>
-        {% endif %}
-        {% if year %}
-          <li>
-            <a href="{% url 'games_by_year' year %}">{{ year }}</a>
-          </li>
-        {% endif %}
-        {% if company %}
-          <li>
-            <a href="{% url 'games_by_company' company.slug %}">{{ company.name }}</a>
-          </li>
-        {% endif %}
-        {% if search_terms %}
-          <li>
-            <a href="{{ request.path }}">Search "{{ search_terms }}"</a>
-          </li>
+          {% if genre %}
+            <li>
+              <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
+            </li>
+          {% endif %}
+          {% if platform %}
+            <li>
+              <a href="/games/platform/{{ platform.slug }}">{{ platform }}</a>
+            </li>
+          {% endif %}
+          {% if year %}
+            <li>
+              <a href="{% url 'games_by_year' year %}">{{ year }}</a>
+            </li>
+          {% endif %}
+          {% if company %}
+            <li>
+              <a href="{% url 'games_by_company' company.slug %}">{{ company.name }}</a>
+            </li>
+          {% endif %}
+          {% if search_terms %}
+            <li>
+              <a href="{{ request.path }}">Search "{{ search_terms }}"</a>
+            </li>
+          {% endif %}
+        </ul>
+
+        <button type="button" class="btn btn-default" data-toggle="collapse"
+            data-target="#filter-mobile" aria-expanded="false" aria-controls="filter-mobile">
+          <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
+        </button>
+      </div>
+
+      <div class="collapse hidden-sm hidden-md hidden-lg" id="filter-mobile"> <!-- "no visible-xs"! -->
+        <div class="pane">
+          <h4>Filter</h4>
+          <form action="." method=get class="form-inline">
+            <div id="advanced-search-panel" class="search-options form-group">
+              <ul>
+                <li>
+                  <input type="checkbox" id="all-open-source" name="all-open-source" {% if all_open_source %}checked{% endif %} />
+                  <label for="all-open-source"><span></span>Only open source games</label>
+                  <ul>
+                    <li>
+                      <input type="checkbox" id="fully-libre-filter" name="fully-libre-filter" {% if fully_libre_filter %}checked{% endif %}/>
+                      <label for="fully-libre-filter"><span></span>Fully libre</label>
+                    </li>
+                    <li>
+                      <input type="checkbox" id="open-engine-filter" name="open-engine-filter" {% if open_engine_filter %}checked{% endif %}/>
+                      <label for="open-engine-filter"><span></span>Libre engine only</label>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+              <ul>
+                <li>
+                  <input type="checkbox" id="all-free" name="all-free" {% if all_free %}checked{% endif %} />
+                  <label for="all-free"><span></span>Only free (gratis) games</label>
+                  <ul>
+                    <li>
+                      <input type="checkbox" id="free-filter" name="free-filter" {% if free_filter %}checked{% endif %}/>
+                      <label for="free-filter"><span></span>Free</label>
+                    </li>
+                    <li>
+                      <input type="checkbox" id="freetoplay-filter" name="freetoplay-filter" {% if freetoplay_filter %}checked{% endif %}/>
+                      <label for="freetoplay-filter"><span></span>Free-to-play</label>
+                    </li>
+                    <li>
+                      <input type="checkbox" id="pwyw-filter" name="pwyw-filter" {% if pwyw_filter %}checked{% endif %}/>
+                      <label for="pwyw-filter"><span></span>Pay what you want</label>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+              <ul>
+                <input type="checkbox" id="unpublished-filter" name="unpublished-filter" {% if unpublished_filter %}checked{% endif %}/>
+                <label for="unpublished-filter"><span></span>Show unpublished games</label>
+              </ul>
+              <span class="input-group-btn">
+                <button class="btn btn-default" type="submit">Apply filter</button>
+              </span>
+            </div>
+          </form>
+          <h4>Platforms</h4>
+          <ul class="filter-list">
+            {% for platform in platforms %}
+              <li><a class="filter-link" href="{% url "games_by_plaform" slug=platform.slug %}">{{ platform.name }}</a></li>
+            {% endfor %}
+          </ul>
+    
+          <h4>Genres</h4>
+          <ul class="filter-list">
+            {% for genre in genres %}
+              <li><a class="filter-link" href="{% url "games_by_genre" genre.slug %}">{{ genre.name }}</a></li>
+            {% endfor %}
+          </ul>
+
+        </div>
+      </div>
+
+      <ul class="game-list">
+        {% for game in games %}
+          {% include "includes/game_preview.html" %}
+        {% endfor %}
+        {% if not games %}
+          <em>
+            No games found that match these criteria.
+            {% if not unpublished_filter %}
+              However, <a href="{% append_to_get unpublished-filter='on' %}">{{ unpublished_match_count }} unpublished games</a> do.
+            {% endif %}
+          </em>
         {% endif %}
       </ul>
-
-    <ul class="game-list">
-      {% for game in games %}
-        {% include "includes/game_preview.html" %}
-      {% endfor %}
-      {% if not games %}
-        <em>No games found that match these criteria.</em>
-      {% endif %}
-    </ul>
 
     {% if page_obj.page_count > 1 %}
       <div class="pagination-block-wrapper">

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -6,10 +6,97 @@
 {% block content %}
 <h1>Games</h1>
 <div class="row">
-  <div class="col-sm-8 col-lg-9">
+
+  <div class="col-sm-4 col-lg-3 col-sm-push-8 col-lg-push-9 collapse" id="filter-controls">
+    <div class="filter-controls-content">
+      <div class="pane">
+            
+        <!-- GENERAL FILTER, SEARCH -->
+        <h4>Filter</h4>
+        <form action="." method="get" class="form-inline">
+          <div class="input-group">
+            <input type="text" name="q" class="search-query form-control"
+                placeholder="Search…" value="{{ search_terms|default:"" }}" />
+          </div>
+          <div id="advanced-search-panel" class="search-options form-group">
+            <ul>
+              <li>
+                <input type="checkbox" id="all-open-source" name="all-open-source"
+                    {% if all_open_source %}checked{% endif %} />
+                <label for="all-open-source"><span></span>Only open source games</label>
+                <ul>
+                  <li>
+                    <input type="checkbox" id="fully-libre-filter" name="fully-libre-filter"
+                        {% if fully_libre_filter %}checked{% endif %} />
+                    <label for="fully-libre-filter"><span></span>Fully libre</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="open-engine-filter" name="open-engine-filter"
+                        {% if open_engine_filter %}checked{% endif %} />
+                    <label for="open-engine-filter"><span></span>Libre engine only</label>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+            <ul>
+              <li>
+                <input type="checkbox" id="all-free" name="all-free"
+                    {% if all_free %}checked{% endif %} />
+                <label for="all-free"><span></span>Only free (gratis) games</label>
+                <ul>
+                  <li>
+                    <input type="checkbox" id="free-filter" name="free-filter"
+                        {% if free_filter %}checked{% endif %} />
+                    <label for="free-filter"><span></span>Free</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="freetoplay-filter" name="freetoplay-filter"
+                        {% if freetoplay_filter %}checked{% endif %}/>
+                    <label for="freetoplay-filter"><span></span>Free-to-play</label>
+                  </li>
+                  <li>
+                    <input type="checkbox" id="pwyw-filter" name="pwyw-filter"
+                        {% if pwyw_filter %}checked{% endif %} />
+                    <label for="pwyw-filter"><span></span>Pay what you want</label>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+            <ul>
+              <input type="checkbox" id="unpublished-filter" name="unpublished-filter"
+                  {% if unpublished_filter %}checked{% endif %} />
+              <label for="unpublished-filter"><span></span>Show unpublished games</label>
+            </ul>
+            <span class="input-group-btn">
+              <button class="btn btn-default" type="submit">Apply filter</button>
+            </span>
+          </div>
+        </form>
+      
+        <!-- PLATFORM FILTER -->
+        <h4>Platforms</h4>
+        <ul class="filter-list">
+          {% for platform in platforms %}
+            <li><a class="filter-link" href="{% url 'games_by_plaform' slug=platform.slug %}">{{ platform.name }}</a></li>
+          {% endfor %}
+        </ul>
+      
+        <!-- GENRE FILTER -->
+        <h4>Genres</h4>
+        <ul class="filter-list">
+          {% for genre in genres %}
+            <li><a class="filter-link" href="{% url 'games_by_genre' genre.slug %}">{{ genre.name }}</a></li>
+          {% endfor %}
+        </ul>
+      
+      </div>
+    </div>
+  </div>
+
+  <div class="col-sm-8 col-lg-9 col-sm-pull-4 col-lg-pull-3">
     <div class="pane">
       <div class="subnav">
-        <ul class='breadcrumb'>
+        <ul class="breadcrumb">
           <li>
             <a href="/games">All</a>
           </li>
@@ -41,80 +128,9 @@
         </ul>
 
         <button type="button" class="btn btn-default" data-toggle="collapse" onclick="blur();"
-            data-target="#filter-mobile" aria-expanded="false" aria-controls="filter-mobile">
+            data-target="#filter-controls" aria-expanded="false" aria-controls="filter-controls">
           <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
         </button>
-      </div>
-
-      <div class="collapse hidden-sm hidden-md hidden-lg" id="filter-mobile">
-        <div class="filter-mobile-content"> <!-- "no visible-xs"! -->
-          <div class="pane">
-
-            <h4>Filter</h4>
-            <form action="." method=get class="form-inline">
-              <div id="advanced-search-panel" class="search-options form-group">
-                <ul>
-                  <li>
-                    <input type="checkbox" id="all-open-source" name="all-open-source" {% if all_open_source %}checked{% endif %} />
-                    <label for="all-open-source"><span></span>Only open source games</label>
-                    <ul>
-                      <li>
-                        <input type="checkbox" id="fully-libre-filter" name="fully-libre-filter" {% if fully_libre_filter %}checked{% endif %}/>
-                        <label for="fully-libre-filter"><span></span>Fully libre</label>
-                      </li>
-                      <li>
-                        <input type="checkbox" id="open-engine-filter" name="open-engine-filter" {% if open_engine_filter %}checked{% endif %}/>
-                        <label for="open-engine-filter"><span></span>Libre engine only</label>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-                <ul>
-                  <li>
-                    <input type="checkbox" id="all-free" name="all-free" {% if all_free %}checked{% endif %} />
-                    <label for="all-free"><span></span>Only free (gratis) games</label>
-                    <ul>
-                      <li>
-                        <input type="checkbox" id="free-filter" name="free-filter" {% if free_filter %}checked{% endif %}/>
-                        <label for="free-filter"><span></span>Free</label>
-                      </li>
-                      <li>
-                        <input type="checkbox" id="freetoplay-filter" name="freetoplay-filter" {% if freetoplay_filter %}checked{% endif %}/>
-                        <label for="freetoplay-filter"><span></span>Free-to-play</label>
-                      </li>
-                      <li>
-                        <input type="checkbox" id="pwyw-filter" name="pwyw-filter" {% if pwyw_filter %}checked{% endif %}/>
-                        <label for="pwyw-filter"><span></span>Pay what you want</label>
-                      </li>
-                    </ul>
-                  </li>
-                </ul>
-                <ul>
-                  <input type="checkbox" id="unpublished-filter" name="unpublished-filter" {% if unpublished_filter %}checked{% endif %}/>
-                  <label for="unpublished-filter"><span></span>Show unpublished games</label>
-                </ul>
-                <span class="input-group-btn">
-                  <button class="btn btn-default" type="submit">Apply filter</button>
-                </span>
-              </div>
-            </form>
-
-            <h4>Platforms</h4>
-            <ul class="filter-list">
-              {% for platform in platforms %}
-                <li><a class="filter-link" href="{% url "games_by_plaform" slug=platform.slug %}">{{ platform.name }}</a></li>
-              {% endfor %}
-            </ul>
-      
-            <h4>Genres</h4>
-            <ul class="filter-list">
-              {% for genre in genres %}
-                <li><a class="filter-link" href="{% url "games_by_genre" genre.slug %}">{{ genre.name }}</a></li>
-              {% endfor %}
-            </ul>
-
-          </div>
-        </div>
       </div>
 
       <ul class="game-list">
@@ -131,113 +147,36 @@
         {% endif %}
       </ul>
 
-    {% if page_obj.page_count > 1 %}
-      <div class="pagination-block-wrapper">
-        <div class="pagination-block">
-          <ul class="pagination-block clearfix">
-            {% if page_obj.number == 1 %}
-            <li><a href="{% append_to_get page=page_obj.next_page_number %}">
-              Next<span style="width: 20px;"></span>&rsaquo;
-            </a></li>
-            {% else %}
-              {% if page_obj.number >= 3 %}
-                <li><a href="{% append_to_get page=1 %}">&laquo;</a></li>
-              {% endif %}
+      {% if page_obj.page_count > 1 %}
+        <div class="pagination-block-wrapper">
+          <div class="pagination-block">
+            <ul class="pagination-block clearfix">
+              {% if page_obj.number == 1 %}
+              <li><a href="{% append_to_get page=page_obj.next_page_number %}">
+                Next<span style="width: 20px;"></span>&rsaquo;
+              </a></li>
+              {% else %}
+                {% if page_obj.number >= 3 %}
+                  <li><a href="{% append_to_get page=1 %}">&laquo;</a></li>
+                {% endif %}
 
-              {% if page_obj.number >= 2 %}
-                <li><a href="{% append_to_get page=page_obj.previous_page_number %}">&lsaquo;</a></li>
-              {% endif %}
+                {% if page_obj.number >= 2 %}
+                  <li><a href="{% append_to_get page=page_obj.previous_page_number %}">&lsaquo;</a></li>
+                {% endif %}
 
-              <li><span>Page {{ page_obj.number }}</span></li>
+                <li><span>Page {{ page_obj.number }}</span></li>
 
-              {% if page_obj.has_next %}
-                <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
+                {% if page_obj.has_next %}
+                  <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
+                {% endif %}
               {% endif %}
-            {% endif %}
-          </ul>
-        </div>
-      </div>
-    {% endif %}
-  </div>
-</div>
-  <div class="col-sm-4 col-lg-3 hidden-xs">
-    <div class="pane">
-      <a href="{% url "game-submit" %}" class="main-button margin-auto">Submit a new game</a>
-      <h4>Search games</h4>
-      <form action="." method=get class="form-inline">
-        <div class="input-group">
-          <input type="text"
-                 name="q"
-                 id="search-entry"
-                 class="search-query form-control"
-                 placeholder="Search…"
-                 value="{{ search_terms|default:"" }}" />
-          <span class="input-group-btn">
-            <button class="btn btn-default" type="submit">Search</button>
-          </span>
-        </div>
-        <div id="advanced-search-panel" class='search-options form-group'>
-          <a href="#advanced-search" class="fold-btn"><span class='fold-indicator'>&#9658;</span> Advanced Search</a>
-          <div class="collapsable-panel {% if show_advanced %}active{% endif %}">
-            <ul>
-              <li>
-                <input type="checkbox" id="all-open-source" name="all-open-source" {% if all_open_source %}checked{% endif %} />
-                <label for="all-open-source"><span></span>Only open source games</label>
-                <ul>
-                  <li>
-                    <input type="checkbox" id="fully-libre-filter" name="fully-libre-filter" {% if fully_libre_filter %}checked{% endif %}/>
-                    <label for="fully-libre-filter"><span></span>Fully libre</label>
-                  </li>
-                  <li>
-                    <input type="checkbox" id="open-engine-filter" name="open-engine-filter" {% if open_engine_filter %}checked{% endif %}/>
-                    <label for="open-engine-filter"><span></span>Libre engine only</label>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-            <ul>
-              <li>
-                <input type="checkbox" id="all-free" name="all-free" {% if all_free %}checked{% endif %} />
-                <label for="all-free"><span></span>Only free (gratis) games</label>
-                <ul>
-                  <li>
-                    <input type="checkbox" id="free-filter" name="free-filter" {% if free_filter %}checked{% endif %}/>
-                    <label for="free-filter"><span></span>Free</label>
-                  </li>
-                  <li>
-                    <input type="checkbox" id="freetoplay-filter" name="freetoplay-filter" {% if freetoplay_filter %}checked{% endif %}/>
-                    <label for="freetoplay-filter"><span></span>Free-to-play</label>
-                  </li>
-                  <li>
-                    <input type="checkbox" id="pwyw-filter" name="pwyw-filter" {% if pwyw_filter %}checked{% endif %}/>
-                    <label for="pwyw-filter"><span></span>Pay what you want</label>
-                  </li>
-                </ul>
-              </li>
-            </ul>
-            <ul>
-              <input type="checkbox" id="unpublished-filter" name="unpublished-filter" {% if unpublished_filter %}checked{% endif %}/>
-              <label for="unpublished-filter"><span></span>Show unpublished games</label>
             </ul>
           </div>
         </div>
-      </form>
-      <h4>Filter by platform</h4>
-      <ul class="filter-list">
-        {% for platform in platforms %}
-        <li><a class="filter-link" href="{% url "games_by_plaform" slug=platform.slug %}">{{ platform.name }}</a></li>
-        {% endfor %}
-      </ul>
-
-      <h4>Filter by genre</h4>
-      <ul class="filter-list">
-        {% for genre in genres %}
-        <li><a class="filter-link" href="{% url "games_by_genre" genre.slug %}">{{ genre.name }}</a></li>
-        {% endfor %}
-      </ul>
-
+      {% endif %}
     </div>
   </div>
+
 </div>
 {% endblock %}
 

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -46,72 +46,74 @@
         </button>
       </div>
 
-      <div class="collapse hidden-sm hidden-md hidden-lg" id="filter-mobile"> <!-- "no visible-xs"! -->
-        <div class="pane">
+      <div class="collapse hidden-sm hidden-md hidden-lg" id="filter-mobile">
+        <div class="filter-mobile-content"> <!-- "no visible-xs"! -->
+          <div class="pane">
 
-          <h4>Filter</h4>
-          <form action="." method=get class="form-inline">
-            <div id="advanced-search-panel" class="search-options form-group">
-              <ul>
-                <li>
-                  <input type="checkbox" id="all-open-source" name="all-open-source" {% if all_open_source %}checked{% endif %} />
-                  <label for="all-open-source"><span></span>Only open source games</label>
-                  <ul>
-                    <li>
-                      <input type="checkbox" id="fully-libre-filter" name="fully-libre-filter" {% if fully_libre_filter %}checked{% endif %}/>
-                      <label for="fully-libre-filter"><span></span>Fully libre</label>
-                    </li>
-                    <li>
-                      <input type="checkbox" id="open-engine-filter" name="open-engine-filter" {% if open_engine_filter %}checked{% endif %}/>
-                      <label for="open-engine-filter"><span></span>Libre engine only</label>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-              <ul>
-                <li>
-                  <input type="checkbox" id="all-free" name="all-free" {% if all_free %}checked{% endif %} />
-                  <label for="all-free"><span></span>Only free (gratis) games</label>
-                  <ul>
-                    <li>
-                      <input type="checkbox" id="free-filter" name="free-filter" {% if free_filter %}checked{% endif %}/>
-                      <label for="free-filter"><span></span>Free</label>
-                    </li>
-                    <li>
-                      <input type="checkbox" id="freetoplay-filter" name="freetoplay-filter" {% if freetoplay_filter %}checked{% endif %}/>
-                      <label for="freetoplay-filter"><span></span>Free-to-play</label>
-                    </li>
-                    <li>
-                      <input type="checkbox" id="pwyw-filter" name="pwyw-filter" {% if pwyw_filter %}checked{% endif %}/>
-                      <label for="pwyw-filter"><span></span>Pay what you want</label>
-                    </li>
-                  </ul>
-                </li>
-              </ul>
-              <ul>
-                <input type="checkbox" id="unpublished-filter" name="unpublished-filter" {% if unpublished_filter %}checked{% endif %}/>
-                <label for="unpublished-filter"><span></span>Show unpublished games</label>
-              </ul>
-              <span class="input-group-btn">
-                <button class="btn btn-default" type="submit">Apply filter</button>
-              </span>
-            </div>
-          </form>
+            <h4>Filter</h4>
+            <form action="." method=get class="form-inline">
+              <div id="advanced-search-panel" class="search-options form-group">
+                <ul>
+                  <li>
+                    <input type="checkbox" id="all-open-source" name="all-open-source" {% if all_open_source %}checked{% endif %} />
+                    <label for="all-open-source"><span></span>Only open source games</label>
+                    <ul>
+                      <li>
+                        <input type="checkbox" id="fully-libre-filter" name="fully-libre-filter" {% if fully_libre_filter %}checked{% endif %}/>
+                        <label for="fully-libre-filter"><span></span>Fully libre</label>
+                      </li>
+                      <li>
+                        <input type="checkbox" id="open-engine-filter" name="open-engine-filter" {% if open_engine_filter %}checked{% endif %}/>
+                        <label for="open-engine-filter"><span></span>Libre engine only</label>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+                <ul>
+                  <li>
+                    <input type="checkbox" id="all-free" name="all-free" {% if all_free %}checked{% endif %} />
+                    <label for="all-free"><span></span>Only free (gratis) games</label>
+                    <ul>
+                      <li>
+                        <input type="checkbox" id="free-filter" name="free-filter" {% if free_filter %}checked{% endif %}/>
+                        <label for="free-filter"><span></span>Free</label>
+                      </li>
+                      <li>
+                        <input type="checkbox" id="freetoplay-filter" name="freetoplay-filter" {% if freetoplay_filter %}checked{% endif %}/>
+                        <label for="freetoplay-filter"><span></span>Free-to-play</label>
+                      </li>
+                      <li>
+                        <input type="checkbox" id="pwyw-filter" name="pwyw-filter" {% if pwyw_filter %}checked{% endif %}/>
+                        <label for="pwyw-filter"><span></span>Pay what you want</label>
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+                <ul>
+                  <input type="checkbox" id="unpublished-filter" name="unpublished-filter" {% if unpublished_filter %}checked{% endif %}/>
+                  <label for="unpublished-filter"><span></span>Show unpublished games</label>
+                </ul>
+                <span class="input-group-btn">
+                  <button class="btn btn-default" type="submit">Apply filter</button>
+                </span>
+              </div>
+            </form>
 
-          <h4>Platforms</h4>
-          <ul class="filter-list">
-            {% for platform in platforms %}
-              <li><a class="filter-link" href="{% url "games_by_plaform" slug=platform.slug %}">{{ platform.name }}</a></li>
-            {% endfor %}
-          </ul>
-    
-          <h4>Genres</h4>
-          <ul class="filter-list">
-            {% for genre in genres %}
-              <li><a class="filter-link" href="{% url "games_by_genre" genre.slug %}">{{ genre.name }}</a></li>
-            {% endfor %}
-          </ul>
+            <h4>Platforms</h4>
+            <ul class="filter-list">
+              {% for platform in platforms %}
+                <li><a class="filter-link" href="{% url "games_by_plaform" slug=platform.slug %}">{{ platform.name }}</a></li>
+              {% endfor %}
+            </ul>
+      
+            <h4>Genres</h4>
+            <ul class="filter-list">
+              {% for genre in genres %}
+                <li><a class="filter-link" href="{% url "games_by_genre" genre.slug %}">{{ genre.name }}</a></li>
+              {% endfor %}
+            </ul>
 
+          </div>
         </div>
       </div>
 
@@ -233,7 +235,6 @@
         <li><a class="filter-link" href="{% url "games_by_genre" genre.slug %}">{{ genre.name }}</a></li>
         {% endfor %}
       </ul>
-
 
     </div>
   </div>

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -8,35 +8,36 @@
 <div class="row">
   <div class="col-sm-8 col-lg-9">
     <div class="pane">
-    <ul class='breadcrumb'>
-      <li>
-        <a href="/games">All</a>
-      </li>
-      {% if genre %}
+      <ul class='breadcrumb'>
         <li>
-          <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
+          <a href="/games">All</a>
         </li>
-      {% endif %}
-      {% if platform %}
-      <li>
-        <a href="/games/platform/{{ platform.slug }}">{{ platform }}</a>
-      </li>
-      {% endif %}
-      {% if year %}
-      <li>
-        <a href="{% url 'games_by_year' year %}">{{ year }}</a>
-      </li>
-      {% endif %}
-      {% if company %}
-      <li>
-        <a href="{% url 'games_by_company' company.slug %}">{{ company.name }}</a>
-      </li>
-      {% endif %}
-      {% if search_terms %}
-      <li><a href="{{ request.path }}">Search "{{ search_terms }}"</a></li>
-
-      {% endif %}
-    </ul>
+        {% if genre %}
+          <li>
+            <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
+          </li>
+        {% endif %}
+        {% if platform %}
+          <li>
+            <a href="/games/platform/{{ platform.slug }}">{{ platform }}</a>
+          </li>
+        {% endif %}
+        {% if year %}
+          <li>
+            <a href="{% url 'games_by_year' year %}">{{ year }}</a>
+          </li>
+        {% endif %}
+        {% if company %}
+          <li>
+            <a href="{% url 'games_by_company' company.slug %}">{{ company.name }}</a>
+          </li>
+        {% endif %}
+        {% if search_terms %}
+          <li>
+            <a href="{{ request.path }}">Search "{{ search_terms }}"</a>
+          </li>
+        {% endif %}
+      </ul>
 
     <ul class="game-list">
       {% for game in games %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -7,6 +7,7 @@
 <h1>Games</h1>
 <div class="row">
 
+  <!-- FILTER CONTROLS -->
   <div class="col-sm-4 col-lg-3 col-sm-push-8 col-lg-push-9 collapse" id="filter-controls">
     <div class="filter-controls-content">
       <div class="pane">
@@ -93,6 +94,7 @@
     </div>
   </div>
 
+  <!-- CONTENT -->
   <div class="col-sm-8 col-lg-9 col-sm-pull-4 col-lg-pull-3">
     <div class="pane">
       <div class="subnav">
@@ -133,6 +135,7 @@
         </button>
       </div>
 
+      <!-- GAME LIST -->
       <ul class="game-list">
         {% for game in games %}
           {% include "includes/game_preview.html" %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -4,7 +4,23 @@
 {% block title %}Games - Lutris{% endblock %}
 
 {% block content %}
-<h1>Games</h1>
+
+<!-- HEADER -->
+<div class="header-wrap">
+  <h1>Games</h1>
+
+  <div class="header-control">
+    <a href="{% url 'game-submit' %}" class="btn btn-default" onclick="blur();">
+      <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+    </a>
+
+    <a href="#" class="btn btn-default" data-toggle="collapse" onclick="blur();"
+        data-target="#filter-controls" aria-expanded="false" aria-controls="filter-controls">
+      <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
+    </a>
+  </div>
+</div>
+
 <div class="row">
 
   <!-- FILTER CONTROLS -->
@@ -99,48 +115,36 @@
   <!-- CONTENT -->
   <div class="col-sm-8 col-lg-9 col-sm-pull-4 col-lg-pull-3">
     <div class="pane">
-      <div class="subnav">
-        <ul class="breadcrumb">
+      <ul class="breadcrumb">
+        <li>
+          <a href="/games">All</a>
+        </li>
+        {% if genre %}
           <li>
-            <a href="/games">All</a>
+            <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
           </li>
-          {% if genre %}
-            <li>
-              <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
-            </li>
-          {% endif %}
-          {% if platform %}
-            <li>
-              <a href="/games/platform/{{ platform.slug }}">{{ platform }}</a>
-            </li>
-          {% endif %}
-          {% if year %}
-            <li>
-              <a href="{% url 'games_by_year' year %}">{{ year }}</a>
-            </li>
-          {% endif %}
-          {% if company %}
-            <li>
-              <a href="{% url 'games_by_company' company.slug %}">{{ company.name }}</a>
-            </li>
-          {% endif %}
-          {% if search_terms %}
-            <li>
-              <a href="{{ request.path }}">Search "{{ search_terms }}"</a>
-            </li>
-          {% endif %}
-        </ul>
-
-        <button type="button" class="btn btn-default" data-toggle="collapse" onclick="blur();"
-            data-target="#filter-controls" aria-expanded="false" aria-controls="filter-controls">
-          <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
-        </button>
-
-        <button type="button" class="btn btn-default" data-toggle="collapse" onclick="blur();"
-            data-target="#filter-controls" aria-expanded="false" aria-controls="filter-controls">
-          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-        </button>
-      </div>
+        {% endif %}
+        {% if platform %}
+          <li>
+            <a href="/games/platform/{{ platform.slug }}">{{ platform }}</a>
+          </li>
+        {% endif %}
+        {% if year %}
+          <li>
+            <a href="{% url 'games_by_year' year %}">{{ year }}</a>
+          </li>
+        {% endif %}
+        {% if company %}
+          <li>
+            <a href="{% url 'games_by_company' company.slug %}">{{ company.name }}</a>
+          </li>
+        {% endif %}
+        {% if search_terms %}
+          <li>
+            <a href="{{ request.path }}">Search "{{ search_terms }}"</a>
+          </li>
+        {% endif %}
+      </ul>
 
       <!-- GAME LIST -->
       <ul class="game-list">

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -44,31 +44,33 @@
       {% endfor %}
     </ul>
 
-    <div class="pagination-block-wrapper">
-      <div class="pagination-block">
-        <ul class="pagination-block clearfix">
-          {% if page_obj.number == 1 %}
-          <li><a href="{% append_to_get page=page_obj.next_page_number %}">
-            Next<span style="width: 20px;"></span>&rsaquo;
-          </a></li>
-          {% else %}
-            {% if page_obj.number >= 3 %}
-              <li><a href="{% append_to_get page=1 %}">&laquo;</a></li>
-            {% endif %}
+    {% if page_obj.page_count > 1 %}
+      <div class="pagination-block-wrapper">
+        <div class="pagination-block">
+          <ul class="pagination-block clearfix">
+            {% if page_obj.number == 1 %}
+            <li><a href="{% append_to_get page=page_obj.next_page_number %}">
+              Next<span style="width: 20px;"></span>&rsaquo;
+            </a></li>
+            {% else %}
+              {% if page_obj.number >= 3 %}
+                <li><a href="{% append_to_get page=1 %}">&laquo;</a></li>
+              {% endif %}
 
-            {% if page_obj.number >= 2 %}
-              <li><a href="{% append_to_get page=page_obj.previous_page_number %}">&lsaquo;</a></li>
-            {% endif %}
+              {% if page_obj.number >= 2 %}
+                <li><a href="{% append_to_get page=page_obj.previous_page_number %}">&lsaquo;</a></li>
+              {% endif %}
 
-            <li><span>Page {{ page_obj.number }}</span></li>
+              <li><span>Page {{ page_obj.number }}</span></li>
 
-            {% if page_obj.has_next %}
-              <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
+              {% if page_obj.has_next %}
+                <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
+              {% endif %}
             {% endif %}
-          {% endif %}
-        </ul>
+          </ul>
+        </div>
       </div>
-    </div>
+    {% endif %}
   </div>
 </div>
   <div class="col-sm-4 col-lg-3 hidden-xs">

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -9,6 +9,8 @@
 
   <!-- FILTER CONTROLS -->
   <div class="col-sm-4 col-lg-3 col-sm-push-8 col-lg-push-9 collapse" id="filter-controls">
+    <a href="{% url 'game-submit' %}" class="main-button margin-auto hidden-xs"
+        style="margin-bottom: 20px;">Submit a new game</a>
     <div class="filter-controls-content">
       <div class="pane">
             

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -48,6 +48,7 @@
 
       <div class="collapse hidden-sm hidden-md hidden-lg" id="filter-mobile"> <!-- "no visible-xs"! -->
         <div class="pane">
+
           <h4>Filter</h4>
           <form action="." method=get class="form-inline">
             <div id="advanced-search-panel" class="search-options form-group">
@@ -96,6 +97,7 @@
               </span>
             </div>
           </form>
+
           <h4>Platforms</h4>
           <ul class="filter-list">
             {% for platform in platforms %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -40,7 +40,7 @@
           {% endif %}
         </ul>
 
-        <button type="button" class="btn btn-default" data-toggle="collapse"
+        <button type="button" class="btn btn-default" data-toggle="collapse" onclick="blur();"
             data-target="#filter-mobile" aria-expanded="false" aria-controls="filter-mobile">
           <span class="glyphicon glyphicon-filter" aria-hidden="true"></span>
         </button>

--- a/templates/includes/game_preview.html
+++ b/templates/includes/game_preview.html
@@ -14,7 +14,7 @@
       <i class="icon-trash"></i><span class="help">Remove from library</span>
     </a>
   {% endif %}
-  <div>
+  <div class="hidden-xs">
     <a href="{{ game.get_absolute_url }}" class="game-title">{{ game.name }}</a>
     {% for platform in game.platforms.all %}
       <a href="{% url "games_by_plaform" slug=platform.slug %}" class="filter-link">{{ platform }}</a>
@@ -23,13 +23,13 @@
       {% for genre in game.genres.all %}
         <a href="{% url 'games_by_genre' genre.slug %}">{{ genre }}</a>
       {% endfor %}
-      {% if  game.year %}
+      {% if game.year %}
         Released in <a href="{% url 'games_by_year' game.year %}">{{ game.year }}</a><br/>
       {% endif %}
-      {% if  game.developer %}
+      {% if game.developer %}
         Developed by <a href="{% url 'games_by_company' game.developer.slug %}">{{ game.developer }}</a>
       {% endif %}
-      {% if  game.publisher %}
+      {% if game.publisher %}
         Published by <a href="{% url 'games_by_company' game.publisher.slug %}">{{ game.publisher }}</a>
       {% endif %}
     </div>


### PR DESCRIPTION
# TL;DR

- Fixes #93 
- Fixes #104 
- General purpose: Improve mobile UX by tweaking CSS/HTML
- **Some changes affect non-mobile views!** However, it's intended.
- Fix an issue where the Lutris logo would break the header on XS
- Remove wasted horizontal/vertical space
- Remove clutter
- Manifold of minor fixes which I didn't bother noting down

# Screenshots

**Please note**: All game banners are low quality because I was too lazy to properly setup the database.

<details>
<summary><strong>Figure 1</strong>: First proof-of-concept. Left: original; Right: improved version</summary>

![design-study](https://user-images.githubusercontent.com/13337480/32148264-81782398-bcf4-11e7-9908-8d6d2526b50e.png)

</details>

<details>
<summary><strong>Figure 2</strong>: <code>/games</code> page. Top nav: global search and menu item. Header nav: submit game, filter</summary>

![screen shot 2017-11-03 at 02 08 33](https://user-images.githubusercontent.com/13337480/32357353-5242cb0a-c03c-11e7-9af4-7b07bea75a4e.png)

</details>

<details>
<summary><strong>Figure 3</strong>: Opened filter page</summary>

![screen shot 2017-11-03 at 02 08 39](https://user-images.githubusercontent.com/13337480/32357368-5f409634-c03c-11e7-8c8f-4465837e2dd6.png)

</details>

<details>
<summary><strong>Figure 4</strong>: Reworked pagination for page 1</summary>

![screen shot 2017-11-03 at 02 08 46](https://user-images.githubusercontent.com/13337480/32357372-63771516-c03c-11e7-8da2-2bad6c7aaf9a.png)

</details>

<details>
<summary><strong>Figure 5</strong>: Reworked pagination for page >= 3</summary>

![screen shot 2017-11-03 at 02 08 53](https://user-images.githubusercontent.com/13337480/32357374-66fa3f10-c03c-11e7-92a1-add736852062.png)

</details>

<details>
<summary><strong>Figure 6</strong>: <code>/library</code> page</summary>

![screen shot 2017-11-03 at 02 09 04](https://user-images.githubusercontent.com/13337480/32357378-6ad44a68-c03c-11e7-9820-4e58fea44827.png)

</details>

<details>
<summary><strong>Figure 7</strong>: <code>/download</code> page</summary>

![screen shot 2017-11-03 at 02 09 11](https://user-images.githubusercontent.com/13337480/32357382-7354a9b2-c03c-11e7-8042-29221bd85ab1.png)

</details>

<details>
<summary><strong>Figure 8</strong>: <code>/</code> page with global search in action</summary>

![screen shot 2017-11-03 at 02 09 35](https://user-images.githubusercontent.com/13337480/32357384-789db8d2-c03c-11e7-8425-7048a6e0964f.png)

</details>

<details>
<summary><strong>Figure 9</strong>: NON-MOBILE: <code>/</code> page. Global search available as well</summary>

![screen shot 2017-11-03 at 02 09 53](https://user-images.githubusercontent.com/13337480/32357387-8092a8f4-c03c-11e7-9215-8510dacd8683.png)

</details>

<details>
<summary><strong>Figure 10</strong>: NON-MOBILE: <code>/</code> page. Global search in action</summary>

![screen shot 2017-11-03 at 02 09 58](https://user-images.githubusercontent.com/13337480/32357394-8c217574-c03c-11e7-8566-33d521cb644f.png)

</details>

<details>
<summary><strong>Figure 11</strong>: NON-MOBILE: <code>/games</code> page. Reworked filter</summary>

![screen shot 2017-11-03 at 02 10 09](https://user-images.githubusercontent.com/13337480/32357397-935155c6-c03c-11e7-827d-af7600abc9d6.png)

</details>

<details>
<summary><strong>Figure 12</strong>: NON-MOBILE: <code>/library</code> page</summary>

![screen shot 2017-11-03 at 02 10 15](https://user-images.githubusercontent.com/13337480/32357403-9d202eec-c03c-11e7-8f7a-54ec6a81173d.png)

</details>

<details>
<summary><strong>Figure 13</strong>: NON-MOBILE: New pagination here, too. Page 2</summary>

![screen shot 2017-11-03 at 02 10 24](https://user-images.githubusercontent.com/13337480/32357404-a032dd28-c03c-11e7-99d7-93ff6b84d5b1.png)

</details>

# Reasoning

- Header:
  - Just show brand on small screens, not the name
  - Show menu and global search for XS screens
  - Global search (for all screen-sizes) as per #93
- Pagination:
  - Old pagination showed way too much data which cluttered the view (must of the data was not relevant)
  - Old pagination links were really hard to click, even with the mouse. Nearly impossible on mobile to hit
  - New pagination for all screen sizes, since the above mentioned points also apply here
- Filter:
  - Genres and Platforms were a bad UX because you had to scroll endlessly to find the right thing. On mobile it was even harder. Tag-cloud like design is better suited in this case, even though I have to say that it still is not optimal
- Pages / general
  - Reworked most pages so they have a `<h1>` header (uniformity + conformity)

# ToDo's

- [x] Smaller paddings/margins in general for XS
- [x] Fix Lutris logo breaking the header on XS
- [x] Smaller headings on XS
- [x] Come up with a appropriate replacement until #93 is resolved, or just resolve #93 
- [x] Improve pagination for mobile use
- [x] Make a filter for mobile
  - [x] Don't display on default, only when needed (see proof-of-concept)
  - [x] Evaluate if existing template can be reused for this purpose
  - [x] Integrate button into the page where it makes sense. (Contrary to proof-of-concept screenshot above: The filter icon is placed in the breadcrumbs-`div`. This does not make sense at all. A new line, on the other hand, would waste horizontal and vertical space)
- [x] Relocate "Submit game" button
- [x] Rework "Download" page
- [x] Rework "Library" page
- [x] Unify layout

# Dependencies

- [x] #93: FIXED ~~It is very uncomfortable and counter-intuitve for the search to be *under* `/games`, below all games on that page, so it should be removed from there, but not without replacement though. So #93 must be done for this MR to be merged~~

# Future work

- Refactor `.less` handling: Don't use one global less file, but make logic units (one file per component for example, with a global file for general purpose)
- More re-usable components to make the look&feel more consistent