### PR TITLE
Allow users to suggest game metadata changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.vscode/
+src/django-jcrop/
+src/django-openid-auth/
 *.pyc
 tags
 lutris.db

--- a/games/admin.py
+++ b/games/admin.py
@@ -180,7 +180,7 @@ class FeaturedAdmin(admin.ModelAdmin):
 
 
 class GameSubmissionAdmin(admin.ModelAdmin):
-    list_display = ("game_link", "user_link", "created_at", "accepted_at")
+    list_display = ("game_link", "user_link", "created_at", "accepted_at", 'reason')
 
     def game_link(self, obj):
         return u"<a href='{0}'>{1}<a/>".format(

--- a/games/admin.py
+++ b/games/admin.py
@@ -4,9 +4,50 @@ from bitfield import BitField
 from bitfield.forms import BitFieldCheckboxSelectMultiple
 from django.contrib import admin
 from django.urls import reverse
+from django.utils.html import format_html
 from reversion.admin import VersionAdmin
 
 from . import forms, models
+
+
+class GameFilter(admin.SimpleListFilter):
+    """Simple filter to remove clutter from the admin panel"""
+
+    title = 'Show'
+    parameter_name = 'change_for'
+
+    def lookups(self, request, model_admin):
+        # Available fitlers
+        return (
+            (None, 'Only games (default)'),
+            ('only-games-with-changes', 'Only games with suggested changes'),
+            ('only-changes', 'Only suggested changes'),
+            ('all', 'All'),
+        )
+
+    def choices(self, cl):
+        for lookup, title in self.lookup_choices:
+            yield {
+                'selected': self.value() == lookup,
+                'query_string': cl.get_query_string({
+                    self.parameter_name: lookup,
+                }, []),
+                'display': title,
+            }
+
+    def queryset(self, request, queryset):
+        # Filter queryset according to the selected filter
+        if self.value() is None:
+            return queryset.filter(change_for__isnull=True)
+        elif self.value() == 'only-games-with-changes':
+            subqueryset = (
+                queryset.values('change_for__id')
+                .filter(change_for__isnull=False)
+                .distinct()
+            )
+            return queryset.filter(change_for__isnull=True, id__in=subqueryset)
+        elif self.value() == 'only-changes':
+            return queryset.filter(change_for__isnull=False)
 
 
 class CompanyAdmin(admin.ModelAdmin):
@@ -68,8 +109,8 @@ class GameAdmin(admin.ModelAdmin):
     ordering = ("-created", )
     form = forms.BaseGameForm
     list_display = ('__unicode__', 'is_public', 'year', 'steamid', 'gogslug',
-                    'humblestoreid', 'created', 'updated', )
-    list_filter = ('is_public', 'publisher', 'developer', 'genres')
+                    'humblestoreid', 'created', 'updated', 'custom_actions')
+    list_filter = (GameFilter, 'is_public', 'publisher', 'developer', 'genres')
     list_editable = ('is_public', )
     search_fields = ('name', 'steamid')
     raw_id_fields = ('publisher', 'developer', 'genres', 'platforms')
@@ -84,6 +125,38 @@ class GameAdmin(admin.ModelAdmin):
         GameMetadataInline,
         GameLinkAdmin
     ]
+    actions = ['reject_user_suggested_changes']
+
+    def custom_actions(self, game):
+        """Column to display additional actions"""
+
+        actions = []
+
+        if game.change_for is not None:
+            actions += [self.review_changes_url(game)]
+        else:
+            change_suggestions_count = models.Game.objects.filter(change_for=game).count()
+
+            if change_suggestions_count > 0:
+                actions += [self.list_change_submissions(game, change_suggestions_count)]
+
+        output = ', '.join(actions) if actions else '-'
+        return format_html(output)
+
+    def review_changes_url(self, game):
+        """Add a link to review the changes of a change submission"""
+
+        url = reverse('admin-change-submission', kwargs={'submission_id': game.id})
+        return '<a href="{url}">{text}</a>'.format(url=url, text='Review changes')
+
+    def list_change_submissions(self, game, count):
+        """Add a link to review all change suggestions for a given game"""
+
+        url = reverse('admin-change-submissions', kwargs={'game_id': game.id})
+        text = '{count} change submission{pl}'.format(count=count, pl='s' if count > 1 else '')
+        return '<a href="{url}">{text}</a>'.format(url=url, text=text)
+
+    custom_actions.short_description = 'Actions'
 
 
 class ScreenshotAdmin(admin.ModelAdmin):

--- a/games/forms.py
+++ b/games/forms.py
@@ -138,11 +138,19 @@ class GameForm(forms.ModelForm):
 class GameEditForm(forms.ModelForm):
     """Form to suggest changes for games"""
 
+    reason = forms.CharField(
+        required=False,
+        help_text=(
+            'Please describe briefly, why this change is necessary.'
+            'Please also add sources if applicable.'
+        )
+    )
+
     class Meta(object):
         """Form configuration"""
 
         model = models.Game
-        fields = ('name', 'year', 'website', 'platforms', 'genres', 'description')
+        fields = ('name', 'year', 'website', 'platforms', 'genres', 'description', 'reason')
         widgets = {
             'platforms': Select2MultipleWidget,
             'genres': Select2MultipleWidget
@@ -155,7 +163,7 @@ class GameEditForm(forms.ModelForm):
         self.fields['year'].label = 'Release year'
 
         fields_order = [
-            'name', 'year', 'website', 'platforms', 'genres', 'description'
+            'name', 'year', 'website', 'platforms', 'genres', 'description', 'reason'
         ]
         self.fields = OrderedDict((k, self.fields[k]) for k in fields_order)
 

--- a/games/models.py
+++ b/games/models.py
@@ -1,4 +1,5 @@
 """Models for main lutris app"""
+
 import datetime
 # pylint: disable=E1002, E0202
 import re
@@ -95,11 +96,12 @@ class Genre(models.Model):
 
 class GameManager(models.Manager):
     def published(self):
-        return self.get_queryset().filter(is_public=True)
+        return self.get_queryset().filter(change_for__isnull=True, is_public=True)
 
     def with_installer(self):
         return (
             self.get_queryset()
+            .filter(change_for__isnull=True)
             .filter(is_public=True)
             .filter(
                 Q(installers__published=True) |
@@ -115,7 +117,7 @@ class GameManager(models.Manager):
             return
         pk_query = self.get_queryset()
         if option == 'incomplete':
-            pk_query = pk_query.filter(year=None)
+            pk_query = pk_query.filter(change_for__isnull=True, year=None)
         elif option == 'published':
             pk_query = self.with_installer()
         elif len(option) > 1:
@@ -140,7 +142,7 @@ class Game(models.Model):
         ('protected', 'Installer modification is restricted'),
     )
     name = models.CharField(max_length=200)
-    slug = models.SlugField(unique=True, blank=False)
+    slug = models.SlugField(unique=True, null=True, blank=True)
     year = models.IntegerField(null=True, blank=True)
     platforms = models.ManyToManyField(Platform)
     genres = models.ManyToManyField(Genre)
@@ -163,6 +165,11 @@ class Game(models.Model):
     humblestoreid = models.CharField(max_length=200, blank=True)
     flags = BitField(flags=GAME_FLAGS)
 
+    # Indicates whether this data row is a changeset for another data row.
+    # If so, this attribute is not NULL and the value is the ID of the
+    # corresponding data row
+    change_for = models.ForeignKey('self', null=True, blank=True)
+
     objects = GameManager()
 
     # pylint: disable=W0232, R0903
@@ -173,7 +180,10 @@ class Game(models.Model):
         )
 
     def __unicode__(self):
-        return self.name
+        if self.change_for is None:
+            return self.name
+        else:
+            return '[Changes for] ' + self.change_for.name
 
     @staticmethod
     def autocomplete_search_fields():
@@ -193,6 +203,51 @@ class Game(models.Model):
     def flag_labels(self):
         """Return labels of active flags, suitable for display"""
         return [self.flags.get_label(flag[0]) for flag in self.flags if flag[1]]
+
+    def get_change_model(self):
+        """Returns a dictionary which can be used as initial value in forms"""
+
+        copy = {
+            'name': self.name,
+            'year': self.year,
+            'website': self.website,
+            'description': self.description,
+            'platforms': [x.id for x in list(self.platforms.all())],
+            'genres': [x.id for x in list(self.genres.all())]
+        }
+
+        return copy
+
+    def get_changes(self):
+        """Returns a dictionary of the changes"""
+
+        changes = []
+        considered_entries = ['name', 'year', 'platforms', 'genres', 'website', 'description']
+
+        # From the considered fields, only those who differ will be returned
+        for entry in considered_entries:
+            old_value = getattr(self.change_for, entry)
+            new_value = getattr(self, entry)
+
+            # M2M relations to string
+            if entry in ['platforms', 'genres']:
+                old_value = ', '.join('[{0}]'.format(str(x)) for x in list(old_value.all()))
+                new_value = ', '.join('[{0}]'.format(str(x)) for x in list(new_value.all()))
+
+            if old_value != new_value:
+                changes.append((entry, old_value, new_value))
+
+        return changes
+
+    def apply_changes(self, change_set):
+        """Applies user-suggested changes to this model"""
+
+        self.name = change_set.name
+        self.year = change_set.year
+        self.platforms.set(change_set.platforms.all())
+        self.genres.set(change_set.genres.all())
+        self.website = change_set.website
+        self.description = change_set.description
 
     def has_installer(self):
         return self.installers.exists() or self.has_auto_installers()
@@ -248,7 +303,6 @@ class Game(models.Model):
         return installers
 
     def check_for_submission(self):
-
         # Skip freshly created and unpublished objects
         if not self.pk or not self.is_public:
             return
@@ -267,12 +321,14 @@ class Game(models.Model):
             submission.accept()
 
     def save(self, force_insert=True, using=None):
-        if not self.slug:
-            self.slug = slugify(self.name)[:50]
-        if not self.slug:
-            raise ValueError("Can't generate a slug for name %s" % self.name)
-        self.download_steam_capsule()
-        self.check_for_submission()
+        # Only create slug etc. if this is a game submission, no change submission
+        if not self.change_for:
+            if not self.slug:
+                self.slug = slugify(self.name)[:50]
+            if not self.slug:
+                raise ValueError("Can't generate a slug for name %s" % self.name)
+            self.download_steam_capsule()
+            self.check_for_submission()
         return super(Game, self).save()
 
 

--- a/games/models.py
+++ b/games/models.py
@@ -620,6 +620,7 @@ class GameSubmission(models.Model):
     game = models.ForeignKey(Game)
     created_at = models.DateTimeField(auto_now_add=True)
     accepted_at = models.DateTimeField(null=True)
+    reason = models.TextField(blank=True)
 
     class Meta:
         verbose_name = "User submitted game"

--- a/games/models.py
+++ b/games/models.py
@@ -620,7 +620,7 @@ class GameSubmission(models.Model):
     game = models.ForeignKey(Game)
     created_at = models.DateTimeField(auto_now_add=True)
     accepted_at = models.DateTimeField(null=True)
-    reason = models.TextField(blank=True)
+    reason = models.TextField(blank=True, null=True)
 
     class Meta:
         verbose_name = "User submitted game"

--- a/games/tests/test_forms.py
+++ b/games/tests/test_forms.py
@@ -69,3 +69,92 @@ class TestGameForm(TestCase):
         })
         self.assertFalse(form.is_valid())
         self.assertIn('name', form.errors)
+
+
+class TestGameEditForm(TestCase):
+    """Test suite for the form to suggest game changes"""
+
+    def setUp(self):
+        name = 'Horribly Misspelled Game Title'
+        platform = factories.PlatformFactory()
+        genre = factories.GenreFactory()
+        year = 2012
+        website = 'https://example.com'
+
+        self.game = factories.GameFactory(name=name)
+        self.game.platforms.set([platform.id])
+        self.game.genres.set([genre.id])
+        self.game.website = website
+        self.game.year = year
+        self.game.description = ''
+        self.game.save()
+
+        self.inputs = {
+            'name': name,
+            'platforms': [platform.id],
+            'genres': [genre.id],
+            'website': website,
+            'year': year,
+            'description': ''
+        }
+
+    def test_user_cannot_submit_unchanged_form(self):
+        """Ensures that a user cannot submit an unchanged form"""
+
+        # Create form
+        form = forms.GameEditForm(self.inputs, initial=self.game.get_change_model())
+
+        # Form should not be valid since no changes were made
+        self.assertFalse(form.is_valid())
+        self.assertIn('You have not changed anything', str(form.errors))
+
+    def test_user_can_submit_valid_changed_form(self):
+        """Ensures that a user can submit valid changes"""
+
+        # Prepare the change to be suggested
+        self.inputs['name'] = 'Corrected Game Title'
+
+        # Needed for the foreign key of the change row
+        change_for = self.game.get_change_model()
+
+        # Create form
+        form = forms.GameEditForm(self.inputs, initial=change_for)
+
+        # Assert that form is valid since the change is valid
+        self.assertTrue(form.is_valid())
+
+        # Persist changes
+        change_suggestion = form.save(commit=False)
+        change_suggestion.change_for = self.game
+        change_suggestion.save()
+        form.save_m2m()
+
+        # Assert that the changes are in the model
+        self.assertEqual(change_suggestion.name, 'Corrected Game Title')
+
+        # Finally, verify the diff (did only the name change?)
+        diff = change_suggestion.get_changes()
+
+        # Count should be 1 since only one change was made
+        self.assertEqual(len(diff), 1)
+
+        # Untie
+        (diff_name, diff_old, diff_new) = diff[0]
+
+        # Verify diff
+        self.assertEqual(diff_name, 'name')
+        self.assertEqual(diff_old, 'Horribly Misspelled Game Title')
+        self.assertEqual(diff_new, 'Corrected Game Title')
+
+    def test_user_cannot_submit_invalid_changed_form(self):
+        """Ensures that a user cannot submit invalid changes"""
+
+        # Prepare the change to be suggested (which is invalid here)
+        self.inputs['name'] = ''
+
+        # Create form
+        form = forms.GameEditForm(self.inputs, initial=self.game.get_change_model())
+
+        # Assert that form is invalid since the name must not be empty
+        self.assertFalse(form.is_valid())
+        self.assertIn('This field is required', str(form.errors['name']))

--- a/games/urls/admin.py
+++ b/games/urls/admin.py
@@ -1,0 +1,25 @@
+"""Routing for custom admin views"""
+
+# pylint: disable=E1120, C0103
+from __future__ import absolute_import
+from django.conf.urls import url
+from games.views import admin as views
+
+
+urlpatterns = [
+    url(r'^change-submissions/$',
+        views.list_change_submissions_view,
+        name='admin-change-submissions'),
+    url(r'^change-submissions/(?P<game_id>\d+)$',
+        views.list_change_submissions_view,
+        name='admin-change-submissions'),
+    url(r'^change-submission/(?P<submission_id>\d+)/$',
+        views.review_change_submission_view,
+        name='admin-change-submission'),
+    url(r'^change-submission/(?P<submission_id>\d+)/accept$',
+        views.change_submission_accept,
+        name='admin-change-submission-accept'),
+    url(r'^change-submission/(?P<submission_id>\d+)/reject$',
+        views.change_submission_reject,
+        name='admin-change-submission-reject'),
+]

--- a/games/urls/pages.py
+++ b/games/urls/pages.py
@@ -30,6 +30,9 @@ urlpatterns = [
     url(r'^game-submitted',
         TemplateView.as_view(template_name='games/submitted.html'),
         name="game-submitted"),
+    url(r'^game-changes-submitted',
+        TemplateView.as_view(template_name='games/submitted-changes.html'),
+        name='game-submitted-changes'),
 
     url('^game-issue',
         views.submit_issue,
@@ -49,6 +52,9 @@ urlpatterns = [
         views.get_installers,
         name='get_installers'),
 
+    url(r'(?P<slug>[\w\-]+)/suggest-changes/$',
+        views.edit_game,
+        name='game-edit'),
     url(r'(?P<slug>[\w\-]+)/installer/new$',
         views.new_installer,
         name="new_installer"),

--- a/games/views/admin.py
+++ b/games/views/admin.py
@@ -1,0 +1,140 @@
+"""Custom admin views"""
+
+from django.conf import settings
+from django.contrib.admin.views.decorators import staff_member_required
+from django.http import HttpResponseForbidden, HttpResponseBadRequest
+from django.shortcuts import get_object_or_404, render, redirect
+from django.urls import reverse
+
+from games import models
+
+
+def redirect_to(request, target):
+    """Helper to redirect to the given target"""
+    redirect_url = target if target[0] == '/' else request.build_absolute_uri(reverse(target))
+
+    # Enforce https
+    if not settings.DEBUG:
+        redirect_url = redirect_url.replace('http:', 'https:')
+
+    return redirect(redirect_url)
+
+
+@staff_member_required
+def list_change_submissions_view(request, game_id=None):
+    """View to list all change submissions"""
+
+    # Check permissions
+    if not request.user.has_perm('games.change_game'):
+        return HttpResponseForbidden("You don't have the permission to review changes")
+
+    # Filter changes if a game_id is given
+    if game_id:
+        game = get_object_or_404(models.Game, id=game_id)
+        change_suggestions_unfiltered = models.Game.objects.filter(change_for=game_id)
+    else:
+        change_suggestions_unfiltered = models.Game.objects.filter(change_for__isnull=False)
+
+    # Generate diffs
+    obsolete_changes = 0
+    change_suggestions = []
+    for change_suggestion in change_suggestions_unfiltered:
+        diff = change_suggestion.get_changes()
+
+        # If the diff is empty, this change is obselete and can be deleted
+        if not diff:
+            change_suggestion.delete()
+            obsolete_changes += 1
+        else:
+            change_suggestion.diff = diff
+            change_suggestions.append(change_suggestion)
+
+    # Determine title
+    title = 'Change submissions'
+    if game_id:
+        title = "{title} for '{name}'".format(title=title, name=game.name)
+
+    context = dict(
+        title=title,
+        obsolete_changes=obsolete_changes,
+        change_suggestions=change_suggestions,
+        for_game=game_id
+    )
+
+    return render(request, 'admin/review-change-submissions.html', context)
+
+
+@staff_member_required
+def review_change_submission_view(request, submission_id):
+    """View to review a specific change submission"""
+
+    # Check permissions
+    if not request.user.has_perm('games.change_game'):
+        return HttpResponseForbidden("You don't have the permission to review changes")
+
+    # Fetch game change DB entry
+    game_changes = get_object_or_404(models.Game, id=submission_id)
+
+    # Sanity check: Must be a change submission
+    if game_changes.change_for is None:
+        return HttpResponseBadRequest('ID must be one of a change submission')
+
+    # Get list of all deltas
+    changes = game_changes.get_changes()
+
+    context = dict(
+        title='Review change submission',
+        submission_id=game_changes.id,
+        changes=changes
+    )
+
+    return render(request, 'admin/review-change-submission.html', context)
+
+
+@staff_member_required
+def change_submission_accept(request, submission_id):
+    """Accept submission and redirect to overview"""
+
+    # Check permissions
+    if not request.user.has_perm('games.change_game'):
+        return HttpResponseForbidden("You don't have the permission to review changes")
+
+    # Fetch game change DB entry
+    game_changes = get_object_or_404(models.Game, id=submission_id)
+
+    # Sanity check: Must be a change submission
+    if game_changes.change_for is None:
+        return HttpResponseBadRequest('ID must be one of a change submission')
+
+    # Apply the changes and delete change entry
+    game = game_changes.change_for
+    game.apply_changes(game_changes)
+    game.save()
+    game_changes.delete()
+
+    # Redirect
+    redirect_target = request.GET.get('redirect', 'admin-change-submissions')
+    return redirect_to(request, redirect_target)
+
+
+@staff_member_required
+def change_submission_reject(request, submission_id):
+    """Reject submission and redirect to overview"""
+
+    # Check permissions
+    if not request.user.has_perm('games.change_game'):
+        return HttpResponseForbidden("You don't have the permission to review changes")
+
+    # Fetch game change DB entry
+    game_changes = get_object_or_404(models.Game, id=submission_id)
+
+    # Sanity check: Must be a change submission
+    if game_changes.change_for is None:
+        return HttpResponseBadRequest('ID must be one of a change submission')
+
+    # Delete change entry
+    game_changes.delete()
+
+    # Redirect
+    redirect_target = request.GET.get('redirect', 'admin-change-submissions')
+    return redirect_to(request, redirect_target)

--- a/games/views/games.py
+++ b/games/views/games.py
@@ -18,11 +18,11 @@ class GameListView(generics.GenericAPIView):
         else:
             game_slugs = []
         if game_slugs:
-            queryset = models.Game.objects.filter(slug__in=game_slugs)
+            queryset = models.Game.objects.filter(change_for__isnull=True, slug__in=game_slugs)
         elif 'random' in self.request.GET:
             queryset = [models.Game.objects.get_random(self.request.GET['random'])]
         else:
-            queryset = models.Game.objects.all()
+            queryset = models.Game.objects.filter(change_for__isnull=True)
         return queryset
 
     def get_serializer_class(self):
@@ -65,10 +65,10 @@ class GameLibraryView(generics.RetrieveAPIView):
 class GameDetailView(generics.RetrieveAPIView):
     serializer_class = serializers.GameSerializer
     lookup_field = 'slug'
-    queryset = models.Game.objects.all()
+    queryset = models.Game.objects.filter(change_for__isnull=True)
 
 
 class GameInstallersView(generics.RetrieveAPIView):
     serializer_class = serializers.GameInstallersSerializer
     lookup_field = 'slug'
-    queryset = models.Game.objects.all()
+    queryset = models.Game.objects.filter(change_for__isnull=True)

--- a/games/views/installers.py
+++ b/games/views/installers.py
@@ -41,7 +41,7 @@ class GameRevisionListView(generics.RetrieveAPIView):
     """Returns the list of revisions """
     permission_classes = [IsAdminUser]
     serializer_class = serializers.GameRevisionSerializer
-    queryset = models.Game.objects.all()
+    queryset = models.Game.objects.filter(change_for__isnull=True)
     lookup_field = 'slug'
 
 

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -491,10 +491,19 @@ def edit_game(request, slug):
 
     # If form was submitted and is valid, persist suggestion for moderation
     if request.method == 'POST' and form.is_valid():
+        # Save the game
         change_suggestion = form.save(commit=False)
         change_suggestion.change_for = game
         change_suggestion.save()
         form.save_m2m()
+
+        # Save metadata (author + reason)
+        change_suggestion_meta = GameSubmission(
+            user=request.user,
+            game=change_suggestion,
+            reason=request.POST['reason']
+        )
+        change_suggestion_meta.save()
 
         redirect_url = request.build_absolute_uri(reverse('game-submitted-changes'))
 

--- a/lutrisweb/urls.py
+++ b/lutrisweb/urls.py
@@ -15,6 +15,7 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^grappelli/', include('grappelli.urls')),
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    url(r'^admin/games/', include('games.urls.admin')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^select2/', include('django_select2.urls')),
     url(r'^openid/', include('django_openid_auth.urls')),

--- a/templates/admin/change-submission.html
+++ b/templates/admin/change-submission.html
@@ -25,14 +25,18 @@
               <th>field</th>
               <td>{{ entry }}</td>
             </tr>
-            <tr style="color: red; background-color: #fbe9eb;">
-              <th>old</th>
-              <td>{{ old_value }}</td>
-            </tr>
-            <tr style="color: green; background-color: #ecfdf0;">
-              <th>new</th>
-              <td>{{ new_value }}</td>
-            </tr>
+            {% if old_value %}
+              <tr style="color: #770000; background-color: #fbe9eb; font-family: monospace;">
+                <th>-</th>
+                <td>{{ old_value }}</td>
+              </tr>
+            {% endif %}
+            {% if new_value %}
+              <tr style="color: #007700; background-color: #ecfdf0; font-family: monospace;">
+                <th>+</th>
+                <td>{{ new_value }}</td>
+              </tr>
+            {% endif %}
           {% endfor %}
         </table>
       </td>

--- a/templates/admin/change-submission.html
+++ b/templates/admin/change-submission.html
@@ -1,0 +1,28 @@
+<div style="margin: 5px; padding: 10px; background-color: #eee; max-width: 600px; 
+    margin-bottom: 15px; box-shadow: 1px 2px 5px 0px rgba(148,148,148,1);">
+  {% if not for_game %}
+  <h4 style="margin-bottom: 5px;">
+    For game: <a href="{% url 'game_detail' change.change_for.slug %}">{{ change.change_for.name }}</a>
+  </h4>
+  {% endif %}
+  <table style="background-color: #fefefe;">
+    <tr>
+      <td></td>
+      <th>Old</th>
+      <th>New</th>
+    </tr>
+    {% for entry, old_value, new_value in change.diff %}
+      <tr><th>{{ entry }}</th><td>{{ old_value }}</td><td>{{ new_value }}</td></tr>
+    {% endfor %}
+  </table>
+
+  <p><strong>Author</strong>: {{ change.author }}</p>
+  <p><strong>Reason</strong>: {{ change.reason }}</p>
+
+  <div style="margin-top: 1em;">
+    <a href="{% url 'admin-change-submission-accept' change.id %}?redirect={{ request.get_full_path }}"
+      class="grp-button grp-default">Accept</a>
+    <a href="{% url 'admin-change-submission-reject' change.id %}?redirect={{ request.get_full_path }}"
+      class="grp-button grp-delete-link">Reject</a>
+  </div>
+</div>

--- a/templates/admin/change-submission.html
+++ b/templates/admin/change-submission.html
@@ -1,28 +1,51 @@
 <div style="margin: 5px; padding: 10px; background-color: #eee; max-width: 600px; 
     margin-bottom: 15px; box-shadow: 1px 2px 5px 0px rgba(148,148,148,1);">
-  {% if not for_game %}
-  <h4 style="margin-bottom: 5px;">
-    For game: <a href="{% url 'game_detail' change.change_for.slug %}">{{ change.change_for.name }}</a>
-  </h4>
-  {% endif %}
-  <table style="background-color: #fefefe;">
+
+  <table style="background-color: #fefefe; width: 100%;">
+    {% if not for_game %}
+      <tr>
+        <th>Changes for</th>
+        <td><a href="{% url 'game_detail' change.change_for.slug %}">{{ change.change_for.name }}</a></td>
+      </tr>
+    {% endif %}
     <tr>
-      <td></td>
-      <th>Old</th>
-      <th>New</th>
+      <th>From</th>
+      <td>{{ change.author }}</td>
     </tr>
-    {% for entry, old_value, new_value in change.diff %}
-      <tr><th>{{ entry }}</th><td>{{ old_value }}</td><td>{{ new_value }}</td></tr>
-    {% endfor %}
+    <tr>
+      <th>Reason</th>
+      <td>{% if change.reason %} {{ change.reason }} {% else %} <em>No reason given</em> {% endif %}</td>
+    </tr>
+    <tr>
+      <th>Diff</th>
+      <td style="padding: 0;">
+        <table style="width: 100%; border: 0;">
+          {% for entry, old_value, new_value in change.diff %}
+            <tr>
+              <th>field</th>
+              <td>{{ entry }}</td>
+            </tr>
+            <tr style="color: red;">
+              <th>old</th>
+              <td>{{ old_value }}</td>
+            </tr>
+            <tr style="color: green;">
+              <th>new</th>
+              <td>{{ new_value }}</td>
+            </tr>
+          {% endfor %}
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <th>Actions</th>
+      <td>
+        <a href="{% url 'admin-change-submission-accept' change.id %}?redirect={{ request.get_full_path }}"
+          class="grp-button grp-default">Accept</a>
+        <a href="{% url 'admin-change-submission-reject' change.id %}?redirect={{ request.get_full_path }}"
+          class="grp-button grp-delete-link">Reject</a>
+      </td>
+    </tr>
   </table>
 
-  <p><strong>Author</strong>: {{ change.author }}</p>
-  <p><strong>Reason</strong>: {{ change.reason }}</p>
-
-  <div style="margin-top: 1em;">
-    <a href="{% url 'admin-change-submission-accept' change.id %}?redirect={{ request.get_full_path }}"
-      class="grp-button grp-default">Accept</a>
-    <a href="{% url 'admin-change-submission-reject' change.id %}?redirect={{ request.get_full_path }}"
-      class="grp-button grp-delete-link">Reject</a>
-  </div>
 </div>

--- a/templates/admin/change-submission.html
+++ b/templates/admin/change-submission.html
@@ -2,38 +2,36 @@
     margin-bottom: 15px; box-shadow: 1px 2px 5px 0px rgba(148,148,148,1);">
 
   <table style="background-color: #fefefe; width: 100%;">
-    {% if not for_game %}
-      <tr>
-        <th>Changes for</th>
-        <td><a href="{% url 'game_detail' change.change_for.slug %}">{{ change.change_for.name }}</a></td>
-      </tr>
-    {% endif %}
     <tr>
-      <th>From</th>
-      <td>{{ change.author }}</td>
+      <th style="text-align: right;">Changes for</th>
+      <td><a href="{% url 'game_detail' change.change_for.slug %}">{{ change.change_for.name }}</a></td>
     </tr>
     <tr>
-      <th>Reason</th>
+      <th style="width: 75px; text-align: right;">From</th>
+      <td><a href="{% url 'admin:accounts_user_change' change.author.id %}">{{ change.author }}</a></td>
+    </tr>
+    <tr>
+      <th style="text-align: right;">Reason</th>
       <td>{% if change.reason %} {{ change.reason }} {% else %} <em>No reason given</em> {% endif %}</td>
     </tr>
     <tr>
-      <th>Diff</th>
+      <th style="text-align: right;">Diff</th>
       <td style="padding: 0;">
         <table style="width: 100%; border: 0;">
           {% for entry, old_value, new_value in change.diff %}
             <tr>
-              <th>field</th>
+              <th style="width: 50px; text-align: right;">field</th>
               <td>{{ entry }}</td>
             </tr>
             {% if old_value %}
               <tr style="color: #770000; background-color: #fbe9eb; font-family: monospace;">
-                <th>-</th>
+                <th style="text-align: right;">--</th>
                 <td>{{ old_value }}</td>
               </tr>
             {% endif %}
             {% if new_value %}
               <tr style="color: #007700; background-color: #ecfdf0; font-family: monospace;">
-                <th>+</th>
+                <th style="text-align: right;">++</th>
                 <td>{{ new_value }}</td>
               </tr>
             {% endif %}
@@ -42,12 +40,15 @@
       </td>
     </tr>
     <tr>
-      <th>Actions</th>
+      <th style="text-align: right;">Actions</th>
       <td>
         <a href="{% url 'admin-change-submission-accept' change.id %}?redirect={{ request.get_full_path }}"
           class="grp-button grp-default">Accept</a>
         <a href="{% url 'admin-change-submission-reject' change.id %}?redirect={{ request.get_full_path }}"
           class="grp-button grp-delete-link">Reject</a>
+        <a href="{% url 'admin:games_game_change' change.id %}"
+          style="color: #309bbf; background: none; border: none;"
+          class="grp-button grp-default">Edit change</a>
       </td>
     </tr>
   </table>

--- a/templates/admin/change-submission.html
+++ b/templates/admin/change-submission.html
@@ -25,11 +25,11 @@
               <th>field</th>
               <td>{{ entry }}</td>
             </tr>
-            <tr style="color: red;">
+            <tr style="color: red; background-color: #fbe9eb;">
               <th>old</th>
               <td>{{ old_value }}</td>
             </tr>
-            <tr style="color: green;">
+            <tr style="color: green; background-color: #ecfdf0;">
               <th>new</th>
               <td>{{ new_value }}</td>
             </tr>

--- a/templates/admin/review-change-submission.html
+++ b/templates/admin/review-change-submission.html
@@ -1,0 +1,32 @@
+{% extends "admin/base_site.html" %}
+{% block breadcrumbs %}
+<ul>
+    <li><a href="../../../">Home</a></li>
+    <li><a href="../../">Games</a></li>
+    <li>{{ title }}</li>
+</ul>
+{% endblock %}
+{% block content %}
+
+<div class="grp-content-container">
+  <table style="max-width: 600px;">
+    <tr>
+      <td></td>
+      <th>Old</th>
+      <th>New</th>
+    </tr>
+    {% for entry, old_value, new_value in changes %}
+      <tr><th>{{entry}}</th><td>{{old_value}}</td><td>{{new_value}}</td></tr>
+    {% endfor %}
+  </table>
+
+  <div style="margin-top: 1em;">
+    <a href="{% url 'admin-change-submission-accept' submission_id %}"
+        class="grp-button grp-default">Accept</a>
+    <a href="{% url 'admin-change-submission-reject' submission_id %}"
+        class="grp-button grp-delete-link">Reject</a>
+  </div>
+
+</div>
+
+{% endblock %}

--- a/templates/admin/review-change-submission.html
+++ b/templates/admin/review-change-submission.html
@@ -9,24 +9,7 @@
 {% block content %}
 
 <div class="grp-content-container">
-  <table style="max-width: 600px;">
-    <tr>
-      <td></td>
-      <th>Old</th>
-      <th>New</th>
-    </tr>
-    {% for entry, old_value, new_value in changes %}
-      <tr><th>{{entry}}</th><td>{{old_value}}</td><td>{{new_value}}</td></tr>
-    {% endfor %}
-  </table>
-
-  <div style="margin-top: 1em;">
-    <a href="{% url 'admin-change-submission-accept' submission_id %}"
-        class="grp-button grp-default">Accept</a>
-    <a href="{% url 'admin-change-submission-reject' submission_id %}"
-        class="grp-button grp-delete-link">Reject</a>
-  </div>
-
+  {% include "admin/change-submission.html" with game="change" %}
 </div>
 
 {% endblock %}

--- a/templates/admin/review-change-submissions.html
+++ b/templates/admin/review-change-submissions.html
@@ -10,34 +10,10 @@
 
 <div class="grp-content-container">
   {% if obsolete_changes > 0 %}
-    <p><strong>INFO:</strong> {{obsolete_changes}} obsolete changes were deleted.</p>
+    <p><strong>INFO:</strong> {{ obsolete_changes }} obsolete changes were deleted.</p>
   {% endif %}
-  {% for c in change_suggestions %}
-    <div style="margin: 5px; padding: 10px; background-color: #eee; max-width: 600px; 
-        margin-bottom: 15px; box-shadow: 1px 2px 5px 0px rgba(148,148,148,1);">
-      {% if not for_game %}
-        <h4 style="margin-bottom: 5px;">
-          For game: <a href="{% url 'game_detail' c.change_for.slug %}">{{c.change_for.name}}</a>
-        </h4>
-      {% endif %}
-      <table style="background-color: #fefefe;">
-        <tr>
-          <td></td>
-          <th>Old</th>
-          <th>New</th>
-        </tr>
-        {% for entry, old_value, new_value in c.diff %}
-          <tr><th>{{entry}}</th><td>{{old_value}}</td><td>{{new_value}}</td></tr>
-        {% endfor %}
-      </table>
-    
-      <div style="margin-top: 1em;">
-        <a href="{% url 'admin-change-submission-accept' c.id %}?redirect={{ request.get_full_path }}"
-            class="grp-button grp-default">Accept</a>
-        <a href="{% url 'admin-change-submission-reject' c.id %}?redirect={{ request.get_full_path }}"
-            class="grp-button grp-delete-link">Reject</a>
-      </div>
-    </div>
+  {% for change in change_suggestions %}
+    {% include "admin/change-submission.html" with game="change" %}
   {% endfor %}
   {% if not change_suggestions %}
     <p>No change suggestions left.</p>

--- a/templates/admin/review-change-submissions.html
+++ b/templates/admin/review-change-submissions.html
@@ -1,0 +1,47 @@
+{% extends "admin/base_site.html" %}
+{% block breadcrumbs %}
+<ul>
+    <li><a href="../../">Home</a></li>
+    <li><a href="../">Games</a></li>
+    <li>{{ title }}</li>
+</ul>
+{% endblock %}
+{% block content %}
+
+<div class="grp-content-container">
+  {% if obsolete_changes > 0 %}
+    <p><strong>INFO:</strong> {{obsolete_changes}} obsolete changes were deleted.</p>
+  {% endif %}
+  {% for c in change_suggestions %}
+    <div style="margin: 5px; padding: 10px; background-color: #eee; max-width: 600px; 
+        margin-bottom: 15px; box-shadow: 1px 2px 5px 0px rgba(148,148,148,1);">
+      {% if not for_game %}
+        <h4 style="margin-bottom: 5px;">
+          For game: <a href="{% url 'game_detail' c.change_for.slug %}">{{c.change_for.name}}</a>
+        </h4>
+      {% endif %}
+      <table style="background-color: #fefefe;">
+        <tr>
+          <td></td>
+          <th>Old</th>
+          <th>New</th>
+        </tr>
+        {% for entry, old_value, new_value in c.diff %}
+          <tr><th>{{entry}}</th><td>{{old_value}}</td><td>{{new_value}}</td></tr>
+        {% endfor %}
+      </table>
+    
+      <div style="margin-top: 1em;">
+        <a href="{% url 'admin-change-submission-accept' c.id %}?redirect={{ request.get_full_path }}"
+            class="grp-button grp-default">Accept</a>
+        <a href="{% url 'admin-change-submission-reject' c.id %}?redirect={{ request.get_full_path }}"
+            class="grp-button grp-delete-link">Reject</a>
+      </div>
+    </div>
+  {% endfor %}
+  {% if not change_suggestions %}
+    <p>No change suggestions left.</p>
+  {% endif %}
+</div>
+
+{% endblock %}

--- a/templates/games/detail.html
+++ b/templates/games/detail.html
@@ -10,14 +10,23 @@
         <img src='{{ MEDIA_URL }}{{ game.icon }}' width='32' height='32' />
       {% endif %}
       <span>{{ game.name }}</span>
-      {% if user.is_staff %}
         <div class="buttons">
-          {% if not game.is_public %}
-            <a class="btn" href="{% url 'game-publish' id=game.id %}">Publish</a>
+          <a class="btn" href="{% url 'game-edit' game.slug %}">Suggest changes</a>
+          {% if user.is_staff %}
+            {% if can_edit and pending_change_subm_count > 0 %}
+              <a class="btn" href="{% url 'admin-change-submissions' game.id %}">
+                {{ pending_change_subm_count }} pending change
+                suggestion{% if pending_change_subm_count > 1 %}s{% endif %}
+              </a>
+            {% endif %}
+            {% if can_publish and not game.is_public %}
+              <a class="btn" href="{% url 'game-publish' id=game.id %}">Publish</a>
+            {% endif %}
+            {% if can_edit %}
+              <a class="btn" href="{% url 'admin:games_game_change' game.id %}">Edit</a>
+            {% endif %}
           {% endif %}
-          <a class="btn" href="{% url 'admin:games_game_change' game.id %}">Edit</a>
         </div>
-      {% endif %}
     </div>
   </div>
 

--- a/templates/games/submit.html
+++ b/templates/games/submit.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% load crispy_forms_tags %}
-{% block title %}Submit a game - Lutris{% endblock %}
+{% block title %}
+{% if not game %} Submit a game {% else %} Suggest changes {% endif %}- Lutris
+{% endblock %}
 {% block extra_head %}
 {{ form.media.css }}
 {% endblock %}
@@ -10,19 +12,27 @@
 <div class="row">
   <div class="col-lg-10 col-lg-offset-1">
     <div class="form-view">
-      <h1>Submit a game</h1>
+      <h1>
+        {% if not game %}
+          Submit a game
+        {% else %}
+          Suggest changes to '{{ game.name }}'
+        {% endif %}
+      </h1>
       <p>
         Please be as accurate as possible with the information you provide.
         Wikipedia or <a href="https://www.mobygames.com/search/quick">Mobygames</a>
         are generally reliable sources. If you know more accurate ones, let us
         know! Thanks for your efforts!<br /><br />
       </p>
+      {% if not game %}
       <p>
         <img src="{% static "images/nosteam.png" %}" alt="Don't submit Steam games" style="float: left; margin-right: 12px;"/>
         <strong>Do not submit Steam games.</strong> We probably already have the game in our database
         (check for unpublished games in the advanced search options). If the game really isn't available,
         sync your Steam library from your Lutris account, this will add missing games to our database.
       </p>
+      {% endif %}
       {% crispy form %}
     </div>
   </div>

--- a/templates/games/submitted-changes.html
+++ b/templates/games/submitted-changes.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block title %}Changes submitted - Lutris{% endblock %}
+
+{% block content %}
+<div class="form-view">
+  <p>
+    Changes submitted, thank you!
+  </p>
+  <p>
+    We will review it as soon as possible.
+  </p>
+  <a href="{% url "game_list" %}">Back to the games list</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
# TL;DR

(*Backup of #101 after I messed that MR up. Sorry!*)

- Fixes #98 (Contribute by editing game metadata)
- Add user functionality: *Submit change suggestions*
- Add admin functionality: *Review change suggestions*, *Accept change suggestions*, *Reject change suggestions* (features bulk-editing)
- Features auto-cleanup when change suggestions became obsolete
- Migration files **not** included. Run `python manage.py makemigrations && python manage.py migrate` beforehand
- I am grateful for feedback

# Screenshots

Here are some screenshots showing the new functionality (may be out of date).

<details>
<summary>Screenshots of the changes considering frontend use</summary>

![screenshot from 2017-10-25 17-31-04](https://user-images.githubusercontent.com/13337480/32007872-14810ef4-b9ab-11e7-9954-59c4cddd7aba.png)
**Figure 1**: New button in the top right corner to get to the change form.  

![screenshot from 2017-10-25 17-31-24](https://user-images.githubusercontent.com/13337480/32007873-14c6a180-b9ab-11e7-80a2-ed6a31974cfc.png)
**Figure 2**: The change form is an altered submission form. Most of the tooltips were not necessary anymore and the banner widget caused issues.  

![screenshot from 2017-10-25 17-31-54](https://user-images.githubusercontent.com/13337480/32007874-14eac6c8-b9ab-11e7-8f28-5bd6b8fc1007.png)
**Figure 3**: A new template to thank the user for the submission.  

</details>

<details>
<summary>Screenshots of the changes considering backend use</summary>

![screenshot from 2017-10-25 17-32-35](https://user-images.githubusercontent.com/13337480/32007875-150d8bf4-b9ab-11e7-9790-8000c36ebee0.png)
**Figure 4**: New filter in the admin panel to filter for *games only*, *changes for games only*, or *all*.  

![screenshot from 2017-10-25 17-32-59](https://user-images.githubusercontent.com/13337480/32007876-1534b896-b9ab-11e7-9abe-5be96497d01f.png)
**Figure 5**: Same view as Figure 4, but filtered for *changes for games only*. Note the column *actions* which links to a review page (see Figure 7).

![screenshot from 2017-10-28 15-15-53](https://user-images.githubusercontent.com/13337480/32134734-b381d110-bbf3-11e7-964d-5143105b8ab9.png)
**Figure 6**: Same view as Figure 4 and Figure 5, but with different data. Here, the filter is set to *all*, showing both games and change suggestions. Note that "Game Beta" has two change submissions pending as indicated in the *actions* column. Clicking on it, will direct to Figure 9.

<img alt="screenshot from 2017-10-25 17-33-21" src="https://user-images.githubusercontent.com/13337480/32007878-15b12b9c-b9ab-11e7-905e-16c9f4d11bf2.png" width="300"></img>
**Figure 7**: New custom admin template to review a submission. It lists the changes only and features buttons to accept or reject a submission.

![screenshot from 2017-10-28 15-18-04](https://user-images.githubusercontent.com/13337480/32134710-44fc05b2-bbf3-11e7-8781-595c2833a65e.png)
**Figure 8**: For staff members with the permission `game.change_game` a button will be displayed if there are change suggestions pending for this game. Clicking on it will redirect you to Figure 9.

![screenshot from 2017-10-28 13-57-50](https://user-images.githubusercontent.com/13337480/32134191-2e2fa6be-bbe8-11e7-81fa-e42e3df832e6.png)
**Figure 9**: An admin view to list all change suggestions for a given game. A similar view is available which lists all change suggestions for any game.

</details>

# Details

- Added a new column to the `games` table, called `change_for`, which is a foreign key to itself. If this field is not `NULL`, then the data row is a changeset for another game, namely the key it holds in `change_for` (*Reason: I wanted to reuse the existing table to not suffer from redundancy*).
- What a user can suggest for editing is controlled by methods in the `Game` model (*Reason: I personally prefer restrictive access control*).
- Change submission rows will be deleted when they get rejected or accepted. If they get accepted, the changes will be applied to the game it references through `change_for`.
- The slugs column had to be changed to allow for a `NULL` value. When a change is created, the slug will be set to `NULL`, since it is not relevant (*Reason: Slugs are `UNIQUE` it wouldn't have worked otherwise, except for random slugs, which would be hacky*).
- Even if the name of a game is changed, the slug will remain the same (*Reason: URL's would change otherwise, leading to 404's if users bookmarked something, SEO issues, ... Slugs should, however, be changed if there's a typo in them or something similar. This can still be done via the conventional admin interface*).

# Misc

- [Removed a part of a Unit test for Game model which had no obvious testing purpose and lead to errors in conjunction with other tests](https://github.com/lutris/website/pull/106/files#diff-c47850c6f1f59fc1ecad6255eeab9b5eL23). You can tell me what this test was supposed to do and we can add a better test which will not error out.
- Hid the button `Edit` on the game details view if the staff member does not have the permission `games.change_game`

# Documentation

- Added documentations for all new modules, functions and methods
- Inline documentations

# Testing

- Form to submit change suggestions (`forms.GameEditForm`)
  - Ensure that a user cannot submit an unchanged form
  - Ensure that a user can submit valid changes
  - Ensure that a user cannot submit invalid changes
- Game model (`models.Game`)
  - Ensure that the form model properly represents the relevant attributes (`get_change_model`)
  - Ensure that `get_changes` properly lists all differences
  - Ensures that `apply_changes` persists the changes


# ToDo's

- [x] Ensure that no other views are effected by the new column, i.e. that other functions filter out games whose `change_for` field is not `NULL`
- [x] Honor permissions (`change_game`)
- [x] Test cases
- [x] Keep track of who submitted a change request
- [x] Offer a field "Reason" so the user can enter his intention for the change request or add sources

# Future work / Backlog

(I don't want to bloat this MR, so I decided to not implement these for now. Let me know if you find one of those mandatory)

- QoL - Review game submission: Make fields editable, add reset (to apply partial changes, fix typos, ....) 
  - **Reason**: Has alternative
  - Change suggestions can be edited in the admin panel anyway. Cumbersome, but it works
- EMail notifications for both staff and user (as feedback)
  - **Reason**: Requirements unclear
  - Do we want this? (Will get pretty verbose for the staff)
  - For games which were curated very carefully, we could implement a `read-only` or `locked` column, which prevents users from suggesting further changes. This can reduce the workload for admins.
- Banner cannot be changed at the moment due to a bug in `ImageField`. Have not found a solution for it yet...
  - **Reason**: Estimated effort high / Requirements unclear
