### PR TITLE
Use npm scripts to avoid globals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ public/js
 public/css
 public/fonts
 node_modules
+npm-debug.log
 reports
 ENV
 celerybeat-schedule

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 setup:
 	npm install
-	bower install --allow-root
-	grunt
+	npm run setup
+
+watch:
+	npm run watch
+
 run:
 	./manage.py runserver 0.0.0.0:8000
 

--- a/README.rst
+++ b/README.rst
@@ -55,27 +55,22 @@ also tell the project to fallback to SQLite::
 Once your virtualenv is created, you can install the system and python
 dependencies::
 
-    sudo apt-get install imagemagick memcached libmemcached-dev mercurial bzr python-dev
+    sudo apt-get install imagemagick memcached libmemcached-dev libxml2-dev libxslt1-dev mercurial bzr python-dev
     make deps
 
 In order to build the frontend code (javascript and css files), you'll
-need nodejs, npm, grunt and bower installed on your system. If you are
+need nodejs and npm installed on your system. If you are
 running Ubuntu, it is advised to use nvm to get the most recent
 version of node, you can install it following the instructions on the github
 page ::
 
     https://github.com/creationix/nvm
 
-Then install bower and grunt::
-
-    npm install -g bower
-    npm install -g grunt-cli
-
-Once you have grunt and bower installed, you can run the following commands::
+Once you installed a recent version of npm, you can run the following commands::
 
     make setup  # Will install the project's npm and bower dependencies
                 # and build the static files
-    grunt watch  # Watch for JS/CSS changes and compile them
+    make watch  # Watch for JS/CSS changes and compile them
 
 You'll need to setup the database, if you want to use a PostgreSQL database,
 follow the instructions found in the next paragraph before running this

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "dependencies": {
   },
   "devDependencies": {
+    "bower": "1.8.2",
     "grunt": "~1.0.1",
+    "grunt-cli": "1.2.0",
     "grunt-browser-sync": "^2.1.3",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
@@ -19,7 +21,8 @@
     "grunt-contrib-watch": "~1.0.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "setup": "bower install --allow-root && grunt",
+    "watch": "grunt watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Just a few chore-changes. *This is a rework of #100, since I messed that MR up. I am genuinely sorry for the inconveniences* 

**TL;DR**

- Don't require `grunt` and `bower` to be global dependencies
- Add `make watch` to substitute `grunt watch`
- Eased instructions in the README
- Ignore node debug files
- if need be, global installs can still be used

**Explanations**

Hey, I just wanted to help out and had issues initially setting up the project\*, so I made the setup more comfortable. A few thoughts:

- You are already primary using `make` for the tasking, so you can basically hide everything there. It's super confusing for new people if they have to deal with that much tasking and packaging stuff. I mean, you got package dependencies, bower, grunt, npm, make, ...
- Using the `scripts` part of the `package.json` is very comfortable to define scripts and tasks, since it adds `node_modules/bin` to its path. No need to install anything globally
- By not having global node deps, you can specifically set the versions so no dev will have issues with weird version incompatibilities 

**\* The issues I had**
The `bower` command was not available, so it crashed when running `make setup`, even though I could run `bower` in the very same terminal without `make` in between.