### PR TITLE
Allow installer contributors to enter reason

### DIFF
--- a/games/forms.py
+++ b/games/forms.py
@@ -253,7 +253,6 @@ class InstallerEditForm(InstallerForm):
 
     def __init__(self, *args, **kwargs):
         super(InstallerEditForm, self).__init__(*args, **kwargs)
-        self.fields['notes'].label = 'Technical notes'
 
 
 class ForkInstallerForm(forms.ModelForm):

--- a/games/forms.py
+++ b/games/forms.py
@@ -161,10 +161,12 @@ class InstallerForm(forms.ModelForm):
     class Meta:
         """Form configuration"""
         model = models.Installer
-        fields = ['runner', 'version', 'description', 'notes', 'content', 'draft']
+        fields = ('runner', 'version', 'description', 'notes', 'content', 'draft')
         widgets = {
             'runner': Select2Widget,
-            'description': forms.Textarea(attrs={'class': 'installer-textarea'}),
+            'description': forms.Textarea(
+                attrs={'class': 'installer-textarea'}
+            ),
             'notes': forms.Textarea(attrs={'class': 'installer-textarea'}),
             'content': forms.Textarea(
                 attrs={'class': 'code-editor', 'spellcheck': 'false'}
@@ -173,37 +175,37 @@ class InstallerForm(forms.ModelForm):
         }
         help_texts = {
             'version': (
-                'Short version name describing the release of the game '
-                'targeted by the installer. It can be the release name (e.g. '
-                'GOTY, Gold...) or format (CD...) or platform (Amiga '
-                '500...), or the vendor version (e.g. GOG, Steam...) or '
-                'the actual software version of the game... Whatever makes '
-                'the most sense.'
+                "Short version name describing the release of the game "
+                "targeted by the installer. It can be the release name (e.g. "
+                "GOTY, Gold...) or format (CD...) or platform (Amiga "
+                "500...), or the vendor version (e.g. GOG, Steam...) or "
+                "the actual software version of the game... Whatever makes "
+                "the most sense."
             ),
-            'description': ('Additional details about the installer. '
-                            'Do NOT put a description for the game, it will be deleted'),
-            'notes': ('Describe any known issues or manual tasks required '
-                      'to run the game properly.'),
+            'description': ("Additional details about the installer. "
+                            "Do NOT put a description for the game, it will be deleted"),
+            'notes': ("Describe any known issues or manual tasks required "
+                      "to run the game properly."),
         }
 
     def __init__(self, *args, **kwargs):
         super(InstallerForm, self).__init__(*args, **kwargs)
-        self.fields['notes'].label = 'Technical notes'
+        self.fields['notes'].label = "Technical notes"
 
     def clean_content(self):
         """Verify that the content field is valid yaml"""
-        yaml_data = self.cleaned_data['content']
+        yaml_data = self.cleaned_data["content"]
         try:
             yaml_data = yaml.safe_load(yaml_data)
         except yaml.scanner.ScannerError:
-            raise forms.ValidationError('Invalid YAML data (scanner error)')
+            raise forms.ValidationError("Invalid YAML data (scanner error)")
         except yaml.parser.ParserError:
-            raise forms.ValidationError('Invalid YAML data (parse error)')
+            raise forms.ValidationError("Invalid YAML data (parse error)")
         except yaml.composer.ComposerError as ex:
             raise forms.ValidationError(
-                'Script error: {problem}. '
-                'Make sure to quote any string with special characters '
-                "such as '*' or ':'".format(problem=ex.problem)
+                "Script error: %s."
+                "Make sure to quote any string with special characters such as '*' or ':'"
+                % ex.problem
             )
         return yaml.safe_dump(yaml_data, default_flow_style=False)
 
@@ -226,7 +228,7 @@ class InstallerForm(forms.ModelForm):
                 self.errors['content'] = []
             for error in errors:
                 self.errors['content'].append(error)
-            raise forms.ValidationError('Invalid installer script')
+            raise forms.ValidationError("Invalid installer script")
         else:
             # Draft status depends on the submit button clicked
             self.cleaned_data['draft'] = 'save' in self.data

--- a/games/forms.py
+++ b/games/forms.py
@@ -161,12 +161,10 @@ class InstallerForm(forms.ModelForm):
     class Meta:
         """Form configuration"""
         model = models.Installer
-        fields = ('runner', 'version', 'description', 'notes', 'content', 'draft')
+        fields = ['runner', 'version', 'description', 'notes', 'content', 'draft']
         widgets = {
             'runner': Select2Widget,
-            'description': forms.Textarea(
-                attrs={'class': 'installer-textarea'}
-            ),
+            'description': forms.Textarea(attrs={'class': 'installer-textarea'}),
             'notes': forms.Textarea(attrs={'class': 'installer-textarea'}),
             'content': forms.Textarea(
                 attrs={'class': 'code-editor', 'spellcheck': 'false'}
@@ -175,37 +173,37 @@ class InstallerForm(forms.ModelForm):
         }
         help_texts = {
             'version': (
-                "Short version name describing the release of the game "
-                "targeted by the installer. It can be the release name (e.g. "
-                "GOTY, Gold...) or format (CD...) or platform (Amiga "
-                "500...), or the vendor version (e.g. GOG, Steam...) or "
-                "the actual software version of the game... Whatever makes "
-                "the most sense."
+                'Short version name describing the release of the game '
+                'targeted by the installer. It can be the release name (e.g. '
+                'GOTY, Gold...) or format (CD...) or platform (Amiga '
+                '500...), or the vendor version (e.g. GOG, Steam...) or '
+                'the actual software version of the game... Whatever makes '
+                'the most sense.'
             ),
-            'description': ("Additional details about the installer. "
-                            "Do NOT put a description for the game, it will be deleted"),
-            'notes': ("Describe any known issues or manual tasks required "
-                      "to run the game properly."),
+            'description': ('Additional details about the installer. '
+                            'Do NOT put a description for the game, it will be deleted'),
+            'notes': ('Describe any known issues or manual tasks required '
+                      'to run the game properly.'),
         }
 
     def __init__(self, *args, **kwargs):
         super(InstallerForm, self).__init__(*args, **kwargs)
-        self.fields['notes'].label = "Technical notes"
+        self.fields['notes'].label = 'Technical notes'
 
     def clean_content(self):
         """Verify that the content field is valid yaml"""
-        yaml_data = self.cleaned_data["content"]
+        yaml_data = self.cleaned_data['content']
         try:
             yaml_data = yaml.safe_load(yaml_data)
         except yaml.scanner.ScannerError:
-            raise forms.ValidationError("Invalid YAML data (scanner error)")
+            raise forms.ValidationError('Invalid YAML data (scanner error)')
         except yaml.parser.ParserError:
-            raise forms.ValidationError("Invalid YAML data (parse error)")
+            raise forms.ValidationError('Invalid YAML data (parse error)')
         except yaml.composer.ComposerError as ex:
             raise forms.ValidationError(
-                "Script error: %s."
-                "Make sure to quote any string with special characters such as '*' or ':'"
-                % ex.problem
+                'Script error: {problem}. '
+                'Make sure to quote any string with special characters '
+                "such as '*' or ':'".format(problem=ex.problem)
             )
         return yaml.safe_dump(yaml_data, default_flow_style=False)
 
@@ -228,11 +226,32 @@ class InstallerForm(forms.ModelForm):
                 self.errors['content'] = []
             for error in errors:
                 self.errors['content'].append(error)
-            raise forms.ValidationError("Invalid installer script")
+            raise forms.ValidationError('Invalid installer script')
         else:
             # Draft status depends on the submit button clicked
             self.cleaned_data['draft'] = 'save' in self.data
             return self.cleaned_data
+
+
+class InstallerEditForm(InstallerForm):
+    """Form to edit an installer"""
+
+    class Meta(InstallerForm.Meta):
+        """Form configuration"""
+
+        fields = ['runner', 'version', 'description', 'notes', 'reason',
+                  'content', 'draft']
+
+    reason = forms.CharField(
+        widget=forms.Textarea(attrs={'class': 'installer-textarea'}),
+        required=False,
+        help_text='Please describe briefly, why this change is necessary or useful. '
+                  'This will help us moderate the changes.'
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(InstallerEditForm, self).__init__(*args, **kwargs)
+        self.fields['notes'].label = 'Technical notes'
 
 
 class ForkInstallerForm(forms.ModelForm):

--- a/games/models.py
+++ b/games/models.py
@@ -520,7 +520,7 @@ class Installer(BaseInstaller):
     # Relevant for edit submissions only: Reason why the proposed change
     # is necessecary or useful
     reason = models.CharField(max_length=512, blank=True, null=True)
-    
+
     # Collection manager
     objects = InstallerManager()
 
@@ -657,6 +657,7 @@ class InstallerRevision(BaseInstaller):
         self.version = installer_data['version']
         self.description = installer_data['description']
         self.notes = installer_data['notes']
+        self.reason = installer_data['reason']
 
         self.installer_id = self._version.object_id
 

--- a/games/models.py
+++ b/games/models.py
@@ -516,6 +516,12 @@ class Installer(BaseInstaller):
     published = models.BooleanField(default=False)
     draft = models.BooleanField(default=False)
     rating = models.CharField(max_length=24, choices=RATINGS.items(), blank=True)
+
+    # Relevant for edit submissions only: Reason why the proposed change
+    # is necessecary or useful
+    reason = models.CharField(max_length=512, blank=True, null=True)
+    
+    # Collection manager
     objects = InstallerManager()
 
     def __unicode__(self):

--- a/games/serializers.py
+++ b/games/serializers.py
@@ -102,6 +102,7 @@ class InstallerRevisionSerializer(serializers.Serializer):
 
     script = serializers.JSONField()
     content = serializers.CharField()
+    reason = serializers.CharField()
     comment = serializers.CharField()
     installer_id = serializers.IntegerField()
 

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -25,7 +25,7 @@ from sorl.thumbnail import get_thumbnail
 from accounts.decorators import user_confirmed_required, check_installer_restrictions
 from games import models
 from games.forms import (ForkInstallerForm, GameForm,
-                         InstallerForm, ScreenshotForm)
+                         InstallerForm, InstallerEditForm, ScreenshotForm)
 from games.models import Game, GameSubmission, Installer, InstallerIssue
 from games.util.pagination import get_page_range
 from platforms.models import Platform
@@ -277,7 +277,7 @@ def edit_installer(request, slug):
         if 'runner_id' in initial_data:
             initial_data['runner'] = initial_data['runner_id']
 
-    form = InstallerForm(request.POST or None, instance=installer, initial=initial_data)
+    form = InstallerEditForm(request.POST or None, instance=installer, initial=initial_data)
     if request.method == 'POST' and form.is_valid():
         with reversion.create_revision():
             installer = form.save(commit=False)

--- a/public/components/installer-review.html
+++ b/public/components/installer-review.html
@@ -23,6 +23,11 @@
     <div class="row">
       <installer-list class="col-sm-2" id="installer-list" installers="[[game.installers]]"></installer-list>
       <div class="col-sm-10 row">
+        <div class="col-sm-12">
+          <div style="margin-top: 1em;">
+            <p hidden="[[ !hasChangeReason ]]"><strong>Reason: </strong>{{ selectedObject.reason }}</p>
+          </div>
+        </div>
         <installer-pane
           class="col-sm-6"
           id="pane-1"
@@ -102,6 +107,11 @@
             type: Boolean,
             value: true,
             computed: 'getHasNoRevision(selectedInstaller)'
+          },
+          hasChangeReason: {
+            type: Boolean,
+            value: false,
+            computed: 'getHasChangeReason(selectedObject)'
           }
         }
       }
@@ -157,6 +167,10 @@
 
       getHasNoRevision(selectedInstaller) {
         return !selectedInstaller.revisions.length;
+      }
+
+      getHasChangeReason(selectedObject) {
+        return (selectedObject && selectedObject.reason && selectedObject.reason != '')
       }
 
       handleResponse(response) {


### PR DESCRIPTION
- Nothing much to say. Fixes #92.
- Migration files not included (CI will fail therefore)

# Screenshots

<details>
<summary><strong>Figure 1</strong>. "Submit new installer" page: Nothing has changed</summary>

![screen shot 2017-11-04 at 14 09 30](https://user-images.githubusercontent.com/13337480/32405652-ceb892f4-c169-11e7-9f78-63b129e657f2.png)

</details>

<details>
<summary><strong>Figure 2</strong>. "Edit installer" page: New field 'Reason'</summary>

![screen shot 2017-11-04 at 14 12 36](https://user-images.githubusercontent.com/13337480/32405683-4b8fc806-c16a-11e7-96a2-7db402d8cfc5.png)

</details>

<details>
<summary><strong>Figure 3</strong>: "Review installer" page: Admins see the reason displayed while reviewing</summary>

![screen shot 2017-11-04 at 14 21 17](https://user-images.githubusercontent.com/13337480/32405744-706aa30c-c16b-11e7-9bfc-651e9c1964e7.png)

</details>