### PR TITLE
Autofocus global search

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -63,7 +63,7 @@
           <div class="search-games-content">
             <form action="{% url 'game_list' %}" method="get" class="form-inline">
               <div class="input-group">
-                <input type="text" name="q" class="search-query form-control"
+                <input type="text" name="q" class="search-query form-control" id="global-search"
                     placeholder="Search…" />
                 <span class="input-group-btn">
                   <button class="btn btn-default" type="submit">Search</button>
@@ -89,8 +89,8 @@
               <li><a href="{% url 'register' %}">Register</a></li>
             {% endif %}
             <li class="hidden-xs">
-              <a href="#" class="collapsed" data-toggle="collapse"
-                  data-target="#search-games" aria-expanded="false" aria-controls="navbar">
+              <a href="#" class="collapsed" data-toggle="collapse" data-target="#search-games"
+                  aria-expanded="false" aria-controls="navbar">
                 <span class="sr-only">Search games</span>
                 <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
             </a>
@@ -180,6 +180,16 @@
   </div>
   <script src="{% static 'js/libs.js' %}"></script>
   <script src="{% static 'js/app.js' %}"></script>
+  <script>
+    $(document).ready(function() {
+      $('#search-games').on('show.bs.collapse', function() {
+        // Wait a little while: calling focus on hidden objects will blur immediately
+        setTimeout(function() {
+          document.getElementById('global-search').focus();
+        }, 50);
+      });
+    });
+  </script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
**This MR is to autofocus the global search one the magnifying glass is clicked**

Had to add a `setTimeout` to make it work. I don't know if there's a better solution, but the bootstrap documentation only shows [4 events](https://getbootstrap.com/docs/3.3/javascript/#collapse-events), and this event is the most appropriate. But when the event is fired, the input seems to not be on `display: block;` head or "visisble enough" for the focus to hold and not immediately blur again.