### PR TITLE
Handle change suggestions in account page

### DIFF
--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -55,9 +55,9 @@
     </section>
 
     <section>
-      <h4>Game submissions</h4>
+      <h4>Submitted contributions</h4>
       {% if submissions %}
-      <p>The following games you submitted are awaiting approval from a
+      <p>The following contributions you submitted are awaiting approval from a
       moderator.</p>
       <ul class="game-list">
         {% for submission in submissions %}
@@ -68,7 +68,7 @@
       </ul>
       {% else %}
       <p>
-        You have no submitted games awaiting approval.
+        You have no submitted contributions awaiting approval.
       </p>
       {% endif %}
     </section>

--- a/templates/includes/game_preview.html
+++ b/templates/includes/game_preview.html
@@ -1,13 +1,21 @@
 {% load thumbnail %}
 
 <li class="clearfix {% if game.has_installer %} with-installer{% endif%}">
-	<a href="{{ game.get_absolute_url }}">
-	{% thumbnail game.title_logo "184x69" crop="center" as img %}
-		<img src="{{ img.url }}" alt="{{ game.name }}" class="game-cover"/>
-	{% empty %}
-		<span class="game-cover">no image</span>
-	{% endthumbnail %}
-	</a>
+  {% if not game.change_for %}
+    <a href="{{ game.get_absolute_url }}">
+      {% thumbnail game.title_logo "184x69" crop="center" as img %}
+        <img src="{{ img.url }}" alt="{{ game.name }}" class="game-cover"/>
+      {% empty %}
+        <span class="game-cover">no image</span>
+      {% endthumbnail %}
+    </a>
+  {% else %}
+    {% thumbnail game.change_for.title_logo "184x69" crop="center" as img %}
+      <img src="{{ img.url }}" alt="{{ game.change_for.name }}" class="game-cover"/>
+    {% empty %}
+      <span class="game-cover">no image</span>
+    {% endthumbnail %}
+  {% endif %}
 
   {% if is_library %}
     <a href="{% url "remove_from_library" slug=game.slug %}" class="right-button">
@@ -15,7 +23,11 @@
     </a>
   {% endif %}
   <div class="hidden-xs">
-    <a href="{{ game.get_absolute_url }}" class="game-title">{{ game.name }}</a>
+    {% if not game.change_for %}
+      <a href="{{ game.get_absolute_url }}" class="game-title">{{ game.name }}</a>
+    {% else %}
+      <a class="game-title">[Change suggestions for] {{ game.change_for.name }}</a>
+    {% endif %}
     {% for platform in game.platforms.all %}
       <a href="{% url "games_by_plaform" slug=platform.slug %}" class="filter-link">{{ platform }}</a>
     {% endfor %}

--- a/templates/includes/game_preview.html
+++ b/templates/includes/game_preview.html
@@ -1,6 +1,6 @@
 {% load thumbnail %}
 
-<li class="clearfix {% if game.has_installer %} with-installer{% endif%}">
+<li class="clearfix {% if game.has_installer %} with-installer{% endif %}">
   {% if not game.change_for %}
     <a href="{{ game.get_absolute_url }}">
       {% thumbnail game.title_logo "184x69" crop="center" as img %}


### PR DESCRIPTION
This is a hotfix for #111 

It basically removes the `hrefs` for change-suggestions, makes the wording more generic and indicates that an entry is a change-suggestion by prefixing it with `[Change suggestions for]`

Screenshot:

![screenshot from 2017-11-05 11-50-40](https://user-images.githubusercontent.com/13337480/32414088-95116cc2-c21f-11e7-9ccc-c211459d0ca8.png)
