### PR TITLE
Rework desktop pagination

### DIFF
--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -273,6 +273,7 @@ input {
       margin: 0;
       background-color: #222;
       border-radius: 4px;
+      font-size: 14px;
 
       li {
         position: relative;
@@ -284,12 +285,12 @@ input {
         display: inline-block;
         color: #AEAEAE;
         margin: 0;
-        padding: 10px 13px;
+        padding: 10px 12px;
       }
 
       li span.glyphicon {
         padding: 0;
-        font-size: 11pt;
+        font-size: 11px;
       }
 
       li a:hover span,

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -256,6 +256,13 @@ input {
 .pagination-block-wrapper {
   margin-top: 20px;
 
+  .meta-information {
+    position: absolute;
+    color: #aaa;
+    font-size: 12px;
+    left: 15px;
+  }
+
   .pagination-block {
     display: table;
     margin: 0 auto;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -284,7 +284,12 @@ input {
         display: inline-block;
         color: #AEAEAE;
         margin: 0;
-        padding: 10px 15px;
+        padding: 10px 13px;
+      }
+
+      li span.glyphicon {
+        padding: 0;
+        font-size: 11pt;
       }
 
       li a:hover span,

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -94,6 +94,7 @@ class GameList(ListView):
         paginator = page.paginator
         page_indexes = get_page_range(paginator.num_pages, page.number)
         page.page_count = page_indexes[-1]
+        page.diff_to_last_page = page.page_count - page.number
         pages = []
         for i in page_indexes:
             if i:

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -167,6 +167,14 @@
 
       {% if page_obj.page_count > 1 %}
         <div class="pagination-block-wrapper">
+          <div class="meta-information hidden-xs" style="color: #aaa; font-size: 12px; position: absolute; left: 15px;">
+            {% if page_obj.start_index == page_obj.end_index %}
+              {{ page_obj.start_index }} of {{ page_obj.paginator.count }}
+            {% else %}
+              {{ page_obj.start_index }}–{{ page_obj.end_index}} of {{ page_obj.paginator.count }}
+            {% endif %}
+          </div>
+
           <div class="pagination-block">
             <ul class="pagination-block clearfix">
               {% if page_obj.number == 1 %}
@@ -187,6 +195,9 @@
                 {% if page_obj.has_next %}
                   <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
                 {% endif %}
+              {% endif %}
+              {% if page_obj.diff_to_last_page > 1 %}
+                <li><a href="{% append_to_get page=page_obj.page_count %}">&raquo;</a></li>
               {% endif %}
             </ul>
           </div>

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -167,7 +167,7 @@
 
       {% if page_obj.page_count > 1 %}
         <div class="pagination-block-wrapper">
-          <div class="meta-information hidden-xs" style="color: #aaa; font-size: 12px; position: absolute; left: 15px;">
+          <div class="meta-information hidden-xs">
             {% if page_obj.start_index == page_obj.end_index %}
               {{ page_obj.start_index }} of {{ page_obj.paginator.count }}
             {% else %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -181,7 +181,7 @@
                 <!-- "Next >" -->
                 <li>
                   <a href="{% append_to_get page=page_obj.next_page_number %}">
-                    <span style="margin: 0; padding: 0; padding-right: 30px;">Next</span>
+                    <span style="margin: 0; padding: 0; padding-right: 24px;">Next</span>
                     <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
                   </a>
                 </li>
@@ -190,7 +190,7 @@
                 {% if page_obj.number >= 3 %}
                   <li>
                     <a href="{% append_to_get page=1 %}">
-                      <span class="glyphicon glyphicon-menu-left" style="margin-right: -13px;" aria-hidden="true"></span>
+                      <span class="glyphicon glyphicon-menu-left" style="margin-right: -10px;" aria-hidden="true"></span>
                       <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
                     </a>
                   </li>
@@ -221,7 +221,7 @@
                 <li>
                   <a href="{% append_to_get page=page_obj.page_count %}">
                     <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
-                    <span class="glyphicon glyphicon-menu-right" style="margin-left: -13px;" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-menu-right" style="margin-left: -10px;" aria-hidden="true"></span>
                   </a>
                 </li>
               {% endif %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -178,26 +178,52 @@
           <div class="pagination-block">
             <ul class="pagination-block clearfix">
               {% if page_obj.number == 1 %}
-              <li><a href="{% append_to_get page=page_obj.next_page_number %}">
-                  <span style="margin: 0; padding: 0; padding-right: 30px;">Next</span>&rsaquo;
-              </a></li>
+                <!-- "Next >" -->
+                <li>
+                  <a href="{% append_to_get page=page_obj.next_page_number %}">
+                    <span style="margin: 0; padding: 0; padding-right: 30px;">Next</span>
+                    <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                  </a>
+                </li>
               {% else %}
+                <!-- "<<"" -->
                 {% if page_obj.number >= 3 %}
-                  <li><a href="{% append_to_get page=1 %}">&laquo;</a></li>
+                  <li>
+                    <a href="{% append_to_get page=1 %}">
+                      <span class="glyphicon glyphicon-menu-left" style="margin-right: -13px;" aria-hidden="true"></span>
+                      <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+                    </a>
+                  </li>
                 {% endif %}
 
+                <!-- "<" -->
                 {% if page_obj.number >= 2 %}
-                  <li><a href="{% append_to_get page=page_obj.previous_page_number %}">&lsaquo;</a></li>
+                  <li>
+                    <a href="{% append_to_get page=page_obj.previous_page_number %}">
+                      <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+                    </a>
+                  </li>
                 {% endif %}
 
                 <li><span>Page {{ page_obj.number }}</span></li>
-
+      
+                <!-- ">" -->
                 {% if page_obj.has_next %}
-                  <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
+                  <li>
+                    <a href="{% append_to_get page=page_obj.next_page_number %}">
+                      <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                    </a>
+                  </li>
                 {% endif %}
               {% endif %}
               {% if page_obj.diff_to_last_page > 1 %}
-                <li><a href="{% append_to_get page=page_obj.page_count %}">&raquo;</a></li>
+                <!-- ">>" -->
+                <li>
+                  <a href="{% append_to_get page=page_obj.page_count %}">
+                    <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-menu-right" style="margin-left: -13px;" aria-hidden="true"></span>
+                  </a>
+                </li>
               {% endif %}
             </ul>
           </div>


### PR DESCRIPTION
As discussed yesterday, I did rework the pagination. Additionally, I changed the `&raquo;` to proper glyphicons. Let me know what else is missing.

These are screenshots of the current state:

<details>
<summary><strong>Figure 1</strong>: Pagination on desktop</summary>

![screen shot 2017-11-05 at 20 51 08](https://user-images.githubusercontent.com/13337480/32418488-3f33072e-c26b-11e7-8727-df17638c7bfd.png)

</details>

<details>
<summary><strong>Figure 2</strong>: Pagination on mobile</summary>

![screen shot 2017-11-05 at 20 51 23](https://user-images.githubusercontent.com/13337480/32418490-4323b89c-c26b-11e7-9d96-0eaab0b3832e.png)

</details>
