### PR TITLE
Rework python linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ install:
 before_script:
   - touch templates/docs/installers.html
 script:
+  - make lint-python
   - make test

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ cleanthumbs:
 	./manage.py thumbnail cleanup
 	rm -rf ./media/cache/
 
+lint-python:
+	pylint --rcfile=config/pylintrc accounts bundles common emails games lutrisweb platforms runners thegamesdb tosec
+
+lint: lint-python
+
 test:
 	SEND_EMAILS=0 ./manage.py test --failfast $(test)
 

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -106,7 +106,7 @@ class EmailConfirmationToken(models.Model):
         try:
             user = User.objects.get(email=self.email)
         except User.DoesNotExist:
-            LOGGER.error("%s tried to confirm but does not exist", self.email)
+            LOGGER.warning("%s tried to confirm but does not exist", self.email)
             return
         except User.MultipleObjectsReturned:
             user = User.objects.filter(email=self.email).order_by('-id')[0]

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -58,6 +58,7 @@ class User(AbstractUser):
         self.gamelibrary.delete()
         self.groups.clear()
         self.authtoken_set.all().delete()
+        self.useropenid_set.all().delete()
         self.username = hmac.new(uuid.uuid4().bytes, digestmod=hashlib.md5).hexdigest()
         self.set_password(hmac.new(uuid.uuid4().bytes, digestmod=hashlib.sha1).hexdigest())
         self.is_active = False

--- a/common/urls.py
+++ b/common/urls.py
@@ -29,5 +29,8 @@ urlpatterns = [
     url(r'upload/',
         views.upload_file,
         name='upload_file'),
+    url(r'faq',
+        TemplateView.as_view(template_name='common/faq.html'),
+        name='faq'),
     url(r'^error-testing/', views.error_testing),
 ]

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -1257,6 +1257,25 @@ input {
   }
 }
 
+/**
+ * Box which shows a error message if applied filters returned
+ * an empty response in a list view
+ */
+.filter-failure-message {
+  width: 100%;
+  text-align: center;
+  font-style: italic;
+
+  & > .filter-failure-icon {
+    color: #444;
+    font-size: 60px;
+  }
+
+  & > p {
+    margin-top: 0 !important;
+  }
+}
+
 .latest-games {
     display: inline-flex;
     flex-wrap: wrap;

--- a/common_static/css/lutris.less
+++ b/common_static/css/lutris.less
@@ -256,6 +256,13 @@ input {
 .pagination-block-wrapper {
   margin-top: 20px;
 
+  .meta-information {
+    position: absolute;
+    color: #aaa;
+    font-size: 12px;
+    left: 15px;
+  }
+
   .pagination-block {
     display: table;
     margin: 0 auto;
@@ -266,6 +273,7 @@ input {
       margin: 0;
       background-color: #222;
       border-radius: 4px;
+      font-size: 14px;
 
       li {
         position: relative;
@@ -277,7 +285,12 @@ input {
         display: inline-block;
         color: #AEAEAE;
         margin: 0;
-        padding: 10px 15px;
+        padding: 10px 12px;
+      }
+
+      li span.glyphicon {
+        padding: 0;
+        font-size: 11px;
       }
 
       li a:hover span,

--- a/config/pylintrc
+++ b/config/pylintrc
@@ -1,38 +1,50 @@
 [MASTER]
 
-# Specify a configuration file.
-#rcfile=
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=migrations
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 #init-hook=
 
-# Profiled execution.
-profile=no
+# Use multiple processes to speed up Pylint.
+jobs=1
 
-# Add files or directories to the blacklist. They should be base names, not
-# paths.
-ignore=migrations,settings
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=pylint_django
 
 # Pickle collected data for later comparisons.
 persistent=yes
 
-# List of plugins (as comma separated values of python modules names) to load,
-# usually to register additional checkers.
-load-plugins=
+# Specify a configuration file.
+#rcfile=
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
 
 
 [MESSAGES CONTROL]
 
-# Enable the message, report, category or checker with the given id(s). You can
-# either give multiple identifier separated by comma (,) or put this option
-# multiple time.
-#enable=
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
-# can either give multiple identifier separated by comma (,) or put this option
-# multiple time (only on the command line, not in the configuration file where
-# it should appear only once).
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).
 # C0111 Missing docstring
 # I0011 Warning locally suppressed using disable-msg
 # I0012 Warning locally suppressed using disable-msg
@@ -50,6 +62,12 @@ load-plugins=
 # R0913 Too many arguments
 # R0904 Too many public methods
 disable=I0011,I0012,C0111,E1101,R0904,W0142,E1002,C1001,E1120,E1123,C0325,R0901,W0232
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=
 
 
 [REPORTS]
@@ -108,7 +126,7 @@ generated-members=objects,status_code
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=90
+max-line-length=100
 
 # Maximum number of lines in a module
 max-module-lines=1000
@@ -159,7 +177,8 @@ class-rgx=[A-Z_][a-zA-Z0-9]+$
 function-rgx=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression which should only match correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+# Snake-case with len(method_name) in range(2, 30) or it begins with 'test_'
+method-rgx=([a-z_][a-z0-9_]{2,30})|(test_[a-z_]+)$
 
 # Regular expression which should only match correct instance attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$

--- a/config/requirements/devel.pip
+++ b/config/requirements/devel.pip
@@ -1,6 +1,7 @@
 -r base.pip
 django-jenkins==0.110.0
 pylint==1.7.4
+pylint-django==0.7.2
 pep8==1.7.1
 coverage==4.4.1
 isort==4.2.15

--- a/fabfile.py
+++ b/fabfile.py
@@ -223,14 +223,6 @@ def deploy():
     supervisor_restart()
 
 
-def fastdeploy():
-    pull()
-    bower()
-    grunt()
-    collect_static()
-    supervisor_restart()
-
-
 def pythonfix():
     """Apply a fix fro Python code only (no migration, no frontend change)"""
     pull()

--- a/fabfile.py
+++ b/fabfile.py
@@ -229,3 +229,9 @@ def fastdeploy():
     grunt()
     collect_static()
     supervisor_restart()
+
+
+def pythonfix():
+    """Apply a fix fro Python code only (no migration, no frontend change)"""
+    pull()
+    supervisor_restart()

--- a/fabfile.py
+++ b/fabfile.py
@@ -80,6 +80,12 @@ def initial_setup():
         run('git clone %s' % LUTRIS_REMOTE)
 
 
+def pip_list():
+    require('environment', provided_by=('staging', 'production'))
+    with cd(env.code_root):
+        with activate():
+            run('pip list')
+
 def requirements():
     require('environment', provided_by=('staging', 'production'))
     with cd(env.code_root):

--- a/games/models.py
+++ b/games/models.py
@@ -6,6 +6,7 @@ import re
 import json
 import random
 from itertools import chain
+from collections import defaultdict
 
 import six
 import reversion
@@ -732,7 +733,11 @@ class InstallerRevision(BaseInstaller):
         except yaml.scanner.ScannerError:
             installer_data['script'] = ['This installer is fucked up.']
         installer_data['id'] = self.id
-        return installer_data
+        # Return a defaultdict to prevent key errors for new fields that
+        # weren't present in previous revisions
+        default_installer_data = defaultdict(str)
+        default_installer_data.update(installer_data)
+        return default_installer_data
 
     def delete(self, using=None, keep_parents=False):
         self._version.delete()

--- a/games/views/admin.py
+++ b/games/views/admin.py
@@ -59,7 +59,7 @@ def list_change_submissions_view(request, game_id=None):
     # Determine title
     title = 'Change submissions'
     if game_id:
-        title = "{title} for '{name}'".format(title=title, name=game.name)
+        title = u"{title} for '{name}'".format(title=title, name=game.name)
 
     context = dict(
         title=title,

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -439,8 +439,12 @@ def get_icon(request, slug):
         game = None
     if not game or not game.icon:
         raise Http404
-    thumbnail = get_thumbnail(game.icon, settings.ICON_SIZE, crop="center",
-                              format="PNG")
+    try:
+        thumbnail = get_thumbnail(game.icon, settings.ICON_SIZE, crop="center",
+                                  format="PNG")
+    except AttributeError:
+        game.icon.delete()
+        raise Http404
     return redirect(thumbnail.url)
 
 

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -97,6 +97,7 @@ class GameList(ListView):
         paginator = page.paginator
         page_indexes = get_page_range(paginator.num_pages, page.number)
         page.page_count = page_indexes[-1]
+        page.diff_to_last_page = page.page_count - page.number
         pages = []
         for i in page_indexes:
             if i:

--- a/lutrisweb/settings/base.py
+++ b/lutrisweb/settings/base.py
@@ -14,7 +14,7 @@ def media_directory(path):
     return abs_path
 
 
-CLIENT_VERSION = "0.4.13"
+CLIENT_VERSION = "0.4.14"
 
 DEBUG = False
 TEMPLATE_DEBUG = DEBUG

--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -55,9 +55,9 @@
     </section>
 
     <section>
-      <h4>Game submissions</h4>
+      <h4>Submitted contributions</h4>
       {% if submissions %}
-      <p>The following games you submitted are awaiting approval from a
+      <p>The following contributions you submitted are awaiting approval from a
       moderator.</p>
       <ul class="game-list">
         {% for submission in submissions %}
@@ -68,7 +68,7 @@
       </ul>
       {% else %}
       <p>
-        You have no submitted games awaiting approval.
+        You have no submitted contributions awaiting approval.
       </p>
       {% endif %}
     </section>

--- a/templates/base.html
+++ b/templates/base.html
@@ -76,8 +76,9 @@
         <!-- MENU COLLAPSE -->
         <div id="navbar" class="navbar-collapse collapse">
           <ul class="nav navbar-nav navbar-right" id="main-nav">
-            <li><a href="{% url 'about' %}">About</a></li>
             <li><a href="{% url 'downloads' %}">Download</a></li>
+            <li><a href="{% url 'about' %}">About</a></li>
+            <li><a href="{% url 'faq' %}">FAQ</a></li>
             <li><a href="{% url 'game_list' %}">Games</a></li>
             <li><a href="https://forums.lutris.net">Forums</a></li>
             {% if user.is_authenticated %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,7 +63,7 @@
           <div class="search-games-content">
             <form action="{% url 'game_list' %}" method="get" class="form-inline">
               <div class="input-group">
-                <input type="text" name="q" class="search-query form-control"
+                <input type="text" name="q" class="search-query form-control" id="global-search"
                     placeholder="Search…" />
                 <span class="input-group-btn">
                   <button class="btn btn-default" type="submit">Search</button>
@@ -89,8 +89,8 @@
               <li><a href="{% url 'register' %}">Register</a></li>
             {% endif %}
             <li class="hidden-xs">
-              <a href="#" class="collapsed" data-toggle="collapse"
-                  data-target="#search-games" aria-expanded="false" aria-controls="navbar">
+              <a href="#" class="collapsed" data-toggle="collapse" data-target="#search-games"
+                  aria-expanded="false" aria-controls="navbar">
                 <span class="sr-only">Search games</span>
                 <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
             </a>
@@ -180,6 +180,16 @@
   </div>
   <script src="{% static 'js/libs.js' %}"></script>
   <script src="{% static 'js/app.js' %}"></script>
+  <script>
+    $(document).ready(function() {
+      $('#search-games').on('show.bs.collapse', function() {
+        // Wait a little while: calling focus on hidden objects will blur immediately
+        setTimeout(function() {
+          document.getElementById('global-search').focus();
+        }, 50);
+      });
+    });
+  </script>
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -78,8 +78,8 @@
           </li>
         </ul>
         <p>
-        Lutris is available in Zugaina's overlay (may not be up to date):
-        <a href="https://gpo.zugaina.org/games-util/lutris">https://gpo.zugaina.org/games-util/lutris</a>.
+        Lutris is available in portage tree:
+        <a href="https://packages.gentoo.org/packages/games-util/lutris">https://packages.gentoo.org/packages/games-util/lutris</a>.
         </p>
       </li>
       <li>

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -6,8 +6,8 @@
 
 <div class='row'>
   <div class="col-md-12">
-    <h2>General</h2>
     <article>
+      <h2>General</h2>
       <h3>Does Lutris sell games</h3>
       <p>
         No, we don't sell commercial games on the platform, Lutris allows you
@@ -23,8 +23,8 @@
           href='https://github.com/lutris/website/issues/83'>on Github</a>
       </p>
     </article>
-    <h3>Wine games</h3>
     <article>
+      <h2>Wine games</h2>
       <h3>The resolution is messed up, how can I fix that?</h3>
       <p>
         Resolution switching for Wine games heavily depends on your hardware

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -8,13 +8,13 @@
   <div class="col-md-12">
     <article>
       <h2>General</h2>
-      <h3>Does Lutris sell games</h3>
+      <h3 id='faq-sell-games'>Does Lutris sell games?</h3>
       <p>
         No, we don't sell commercial games on the platform, Lutris allows you
         to install and play games purchased on a variety on different game stores such as
         Steam, Humble Bundle, GOG, Battle.net, etc…
       </p>
-      <h3>I'm a game developer, can I publish my game on Lutris</h3>
+      <h3 id='faq-game-dev'>I'm a game developer, can I publish my game on Lutris?</h3>
       <p>
         You can create a page for your game and submit an installer for it but
         right now there aren't any special features for game developers. We do
@@ -22,10 +22,25 @@
         follow its development here: <a
           href='https://github.com/lutris/website/issues/83'>on Github</a>
       </p>
+      <h3 id='faq-runtime'>What is the Lutris runtime?</h3>
+      <p>
+        The Lutris runtime is a collection of libraries we automatically
+        provide to ensure compatibility with all games and runners over all
+        Linux distributions. The runtime itself is composed of parts of the <a
+          href="https://github.com/ValveSoftware/steam-runtime">Steam
+          runtime</a>, some Ubuntu 16.04 libraries and a few extra libraries
+        from various places.<br/>
+        Of course, ensuring binary compatibility over all existing Linux
+        distributions is not an easy task and sometimes issues will arise. If
+        such a thing happen, try disabling the runtime in the system options of
+        your game. For more details on the runtime, see the <a
+          href="https://github.com/lutris/lutris/wiki/Lutris-Runtime">wiki</a>.
+      </p>
     </article>
+
     <article>
       <h2>Runners</h2>
-      <h3>What is a "Runner"?</h3>
+      <h3 id='faq-runner'>What is a "Runner"?</h3>
       <p>
         A "runner" is the term we use to refer to programs that can run games,
         it can be Linux itself, Wine, DOSBox, MAME, gzdoom, …
@@ -36,22 +51,23 @@
         one or two.
       </p>
       <h3>I want to use your runners but I don't care for Lutris itself</h3>
-      <p>
+      <p id='faq-download-runners'>
         Aww, that's too bad… :( But don't worry! All our runner builds are
         freely downloadable from <a
           href="https://lutris.net/files/runners/">here</a>.
       </p>
     </article>
+
     <article>
       <h2>Wine games</h2>
-      <h3>How do I change the Wine version used in a game</h3>
+      <h3 id='faq-wine-versions'>How do I change the Wine version used in a game?</h3>
       <p>
         If you already have a version of Wine installed, you should see a Wine
         entry on the sidebar, you can right click on it then select "Manage
         versions". From there you can install or remove any Wine build we
         provide. The wine versions are downloaded to <code>~/.local/share/lutris/runners/wine/</code>
       </p>
-      <h3>The resolution is messed up, how can I fix that?</h3>
+      <h3 id='faq-wine-resolution'>The resolution is messed up, how can I fix that?</h3>
       <p>
         Resolution switching for Wine games heavily depends on your hardware
         and your desktop environment and also the game itself.<br/>
@@ -60,7 +76,7 @@
         native resolution. Once the game is using your native resolution, you
         should be able to turn off the virtual desktop.
       </p>
-      <h3>I'm just here for Overwatch, don't care about anything else</h3>
+      <h3 id='faq-overwatch'>I'm just here for Overwatch, don't care about anything else</h3>
       <p>
         Please refer to the following article <a
           href="https://github.com/lutris/lutris/wiki/Game:-Overwatch">on the

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -34,6 +34,12 @@
         native resolution. Once the game is using your native resolution, you
         should be able to turn off the virtual desktop.
       </p>
+      <h3>I'm just here for Overwatch, don't care about anything else</h3>
+      <p>
+        Please refer to the following article <a
+          href="https://github.com/lutris/lutris/wiki/Game:-Overwatch">on the
+          Github wiki</a>
+      </p>
     </article>
 
 

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -104,6 +104,13 @@
         native resolution. Once the game is using your native resolution, you
         should be able to turn off the virtual desktop.
       </p>
+      <h3 id='faq-winemenubuilder'>I get winemenubuilder.exe errors in the console output</h3>
+      <p>
+        You shouldn't worry about those. We explicitely disable winemenubuilder
+        at runtime so it doesn't mess with your Linux desktop's file type
+        associations. Any error related to winemenubuilder can be safely
+        ignored.
+      </p>
       <h3 id='faq-overwatch'>I'm just here for Overwatch, don't care about anything else</h3>
       <p>
         Please refer to the following article <a

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -14,6 +14,14 @@
         to install and play games purchased on a variety on different game stores such as
         Steam, Humble Bundle, GOG, Battle.net, etc…
       </p>
+      <h3 id='faq-community'>How do I get in touch with the Lutris community?</h3>
+      <p>
+        If you want to ask questions about Lutris or just hang out with other Lutris users, you can join our
+        <a href="https://discord.gg/GC8vA6C">Discord channel</a> or our IRC channel
+        <a href="irc://irc.freenode.org:6667/lutris">#lutris on freenode.org</a>.
+        You can also use the <a href="https://forums.lutris.net/">forums</a> to ask questions.
+      </p>
+
       <h3 id='faq-game-dev'>I'm a game developer, can I publish my game on Lutris?</h3>
       <p>
         You can create a page for your game and submit an installer for it but
@@ -35,6 +43,18 @@
         such a thing happen, try disabling the runtime in the system options of
         your game. For more details on the runtime, see the <a
           href="https://github.com/lutris/lutris/wiki/Lutris-Runtime">wiki</a>.
+      </p>
+      <h3 id='faq-game-crash'>Game [x] crashes, what should I do?</h3>
+      <p>
+        First run Lutris from a command line to see potential errors from the game.
+        If you see errors related to Linux libraries, try running the game with
+        the <a href='#faq-runtime'>runtime</a> disabled. If disabling the
+        runtime fixes the issue, please, notify the developers, we don't want
+        to ship a broken runtime and your input can help fixing it.<br/>
+        If your game still doesn't launch try collecting as much info about
+        your setup (name of the game, your graphics drivers, Linux distributin,
+        hardware setup, desktop environment, …) and explain your issue to the
+        <a href="#faq-community">community</a>.
       </p>
     </article>
 

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block title %}Lutris F.A.Q.{% endblock title %}
+
+{% block content %}
+<h1>Frequently asked questions</h1>
+
+<div class='row'>
+  <div class="col-md-12">
+    <h2>General</h2>
+    <article>
+      <h3>Does Lutris sell games</h3>
+      <p>
+        No, we don't sell commercial games on the platform, Lutris allows you
+        to install and play games purchased on a variety on different game stores such as
+        Steam, Humble Bundle, GOG, Battle.net, etc…
+      </p>
+      <h3>I'm a game developer, can I publish my game on Lutris</h3>
+      <p>
+        You can create a page for your game and submit an installer for it but
+        right now there aren't any special features for game developers. We do
+        have some plan to add a game developer role to the website, you can
+        follow its development here: <a
+          href='https://github.com/lutris/website/issues/83'>on Github</a>
+      </p>
+    </article>
+    <h3>Wine games</h3>
+    <article>
+      <h3>The resolution is messed up, how can I fix that?</h3>
+      <p>
+        Resolution switching for Wine games heavily depends on your hardware
+        and your desktop environment and also the game itself.<br/>
+        If you are experiencing issues, try using a virtual desktop in the Wine
+        runner options then start the game and set it to use your monitor's
+        native resolution. Once the game is using your native resolution, you
+        should be able to turn off the virtual desktop.
+      </p>
+    </article>
+
+
+  </div>
+</div>
+{% endblock content %}

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -55,6 +55,14 @@
         your setup (name of the game, your graphics drivers, Linux distributin,
         hardware setup, desktop environment, …) and explain your issue to the
         <a href="#faq-community">community</a>.
+        If you want to troubleshoot the issue yourself, there are some good
+        resources you can look into. Start by looking up the game in <a
+          href="https://pcgamingwiki.com">PCGamingWiki</a> as you might run
+        into a know problem and they might have a workaround. If you are trying
+        to run a Windows game, also check out <a
+          href="https://appdb.winehq.org/">WineHQ's AppDB</a> or look for
+        issues other Windows users are running into, in the Steam forums for
+        example.
       </p>
     </article>
 

--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -24,7 +24,33 @@
       </p>
     </article>
     <article>
+      <h2>Runners</h2>
+      <h3>What is a "Runner"?</h3>
+      <p>
+        A "runner" is the term we use to refer to programs that can run games,
+        it can be Linux itself, Wine, DOSBox, MAME, gzdoom, …
+        Runners are recognized as such in Lutris itself, not all programs that
+        run games are considered runners. For example Darkplaces, the open
+        source engine for Quake is not a runner but gzdoom is. Usually,
+        programs become runners if they can run a variety of games, not just
+        one or two.
+      </p>
+      <h3>I want to use your runners but I don't care for Lutris itself</h3>
+      <p>
+        Aww, that's too bad… :( But don't worry! All our runner builds are
+        freely downloadable from <a
+          href="https://lutris.net/files/runners/">here</a>.
+      </p>
+    </article>
+    <article>
       <h2>Wine games</h2>
+      <h3>How do I change the Wine version used in a game</h3>
+      <p>
+        If you already have a version of Wine installed, you should see a Wine
+        entry on the sidebar, you can right click on it then select "Manage
+        versions". From there you can install or remove any Wine build we
+        provide. The wine versions are downloaded to <code>~/.local/share/lutris/runners/wine/</code>
+      </p>
       <h3>The resolution is messed up, how can I fix that?</h3>
       <p>
         Resolution switching for Wine games heavily depends on your hardware
@@ -41,8 +67,6 @@
           Github wiki</a>
       </p>
     </article>
-
-
   </div>
 </div>
 {% endblock content %}

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -115,6 +115,8 @@
   <!-- CONTENT -->
   <div class="col-sm-8 col-lg-9 col-sm-pull-4 col-lg-pull-3">
     <div class="pane">
+
+      <!-- BREADCRUMBS -->
       <ul class="breadcrumb">
         <li>
           <a href="/games">All</a>
@@ -146,24 +148,35 @@
         {% endif %}
       </ul>
 
-      <!-- GAME LIST -->
-      <ul class="game-list">
-        {% for game in games %}
-          {% include "includes/game_preview.html" %}
-        {% endfor %}
-        {% if not games %}
-          <p><em>No games found that match these criteria.</em></p>
+      <!-- CONTENT: GAME LIST | MESSAGE -->
+      {% if games %}
+        <ul class="game-list">
+          {% for game in games %}
+            {% include 'includes/game_preview.html' %}
+          {% endfor %}
+        </ul>
+      {% else %}
+        <div class="filter-failure-message">
+          <p class="filter-failure-icon">
+            <span class="glyphicon glyphicon-alert"></span>
+          </p>
+          <p>No games found that match these criteria.</p>
           {% if not unpublished_filter and unpublished_match_count > 0 %}
             <p>
-              <em>However, <a href="{% append_to_get unpublished-filter='on' %}">{{ unpublished_match_count }} unpublished games</a> do.</em>
+              However, <a href="{% append_to_get unpublished-filter='on' %}">{{ unpublished_match_count }} unpublished
+              {% if unpublished_match_count == 1 %}
+                game</a> does.
+              {% else %}
+                games</a> do.
+              {% endif %}
             </p>
           {% else %}
             <p>
-              <em>Feel free to <a href="{% url 'game-submit' %}">add the game</a> to our database.</em>
+              Feel free to <a href="{% url 'game-submit' %}">add the game</a> to our database.
             </p>
           {% endif %}
-        {% endif %}
-      </ul>
+        </div>
+      {% endif %}
 
       {% if page_obj.page_count > 1 %}
         <div class="pagination-block-wrapper">

--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -180,26 +180,63 @@
 
       {% if page_obj.page_count > 1 %}
         <div class="pagination-block-wrapper">
+          <div class="meta-information hidden-xs">
+            {% if page_obj.start_index == page_obj.end_index %}
+              {{ page_obj.start_index }} of {{ page_obj.paginator.count }}
+            {% else %}
+              {{ page_obj.start_index }}–{{ page_obj.end_index}} of {{ page_obj.paginator.count }}
+            {% endif %}
+          </div>
+
           <div class="pagination-block">
             <ul class="pagination-block clearfix">
               {% if page_obj.number == 1 %}
-              <li><a href="{% append_to_get page=page_obj.next_page_number %}">
-                  <span style="margin: 0; padding: 0; padding-right: 30px;">Next</span>&rsaquo;
-              </a></li>
+                <!-- "Next >" -->
+                <li>
+                  <a href="{% append_to_get page=page_obj.next_page_number %}">
+                    <span style="margin: 0; padding: 0; padding-right: 24px;">Next</span>
+                    <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                  </a>
+                </li>
               {% else %}
+                <!-- "<<"" -->
                 {% if page_obj.number >= 3 %}
-                  <li><a href="{% append_to_get page=1 %}">&laquo;</a></li>
+                  <li>
+                    <a href="{% append_to_get page=1 %}">
+                      <span class="glyphicon glyphicon-menu-left" style="margin-right: -10px;" aria-hidden="true"></span>
+                      <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+                    </a>
+                  </li>
                 {% endif %}
 
+                <!-- "<" -->
                 {% if page_obj.number >= 2 %}
-                  <li><a href="{% append_to_get page=page_obj.previous_page_number %}">&lsaquo;</a></li>
+                  <li>
+                    <a href="{% append_to_get page=page_obj.previous_page_number %}">
+                      <span class="glyphicon glyphicon-menu-left" aria-hidden="true"></span>
+                    </a>
+                  </li>
                 {% endif %}
 
                 <li><span>Page {{ page_obj.number }}</span></li>
-
+      
+                <!-- ">" -->
                 {% if page_obj.has_next %}
-                  <li><a href="{% append_to_get page=page_obj.next_page_number %}">&rsaquo;</a></li>
+                  <li>
+                    <a href="{% append_to_get page=page_obj.next_page_number %}">
+                      <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                    </a>
+                  </li>
                 {% endif %}
+              {% endif %}
+              {% if page_obj.diff_to_last_page > 1 %}
+                <!-- ">>" -->
+                <li>
+                  <a href="{% append_to_get page=page_obj.page_count %}">
+                    <span class="glyphicon glyphicon-menu-right" aria-hidden="true"></span>
+                    <span class="glyphicon glyphicon-menu-right" style="margin-left: -10px;" aria-hidden="true"></span>
+                  </a>
+                </li>
               {% endif %}
             </ul>
           </div>

--- a/templates/includes/game_preview.html
+++ b/templates/includes/game_preview.html
@@ -1,13 +1,21 @@
 {% load thumbnail %}
 
-<li class="clearfix {% if game.has_installer %} with-installer{% endif%}">
-	<a href="{{ game.get_absolute_url }}">
-	{% thumbnail game.title_logo "184x69" crop="center" as img %}
-		<img src="{{ img.url }}" alt="{{ game.name }}" class="game-cover"/>
-	{% empty %}
-		<span class="game-cover">no image</span>
-	{% endthumbnail %}
-	</a>
+<li class="clearfix {% if game.has_installer %} with-installer{% endif %}">
+  {% if not game.change_for %}
+    <a href="{{ game.get_absolute_url }}">
+      {% thumbnail game.title_logo "184x69" crop="center" as img %}
+        <img src="{{ img.url }}" alt="{{ game.name }}" class="game-cover"/>
+      {% empty %}
+        <span class="game-cover">no image</span>
+      {% endthumbnail %}
+    </a>
+  {% else %}
+    {% thumbnail game.change_for.title_logo "184x69" crop="center" as img %}
+      <img src="{{ img.url }}" alt="{{ game.change_for.name }}" class="game-cover"/>
+    {% empty %}
+      <span class="game-cover">no image</span>
+    {% endthumbnail %}
+  {% endif %}
 
   {% if is_library %}
     <a href="{% url "remove_from_library" slug=game.slug %}" class="right-button">
@@ -15,7 +23,11 @@
     </a>
   {% endif %}
   <div class="hidden-xs">
-    <a href="{{ game.get_absolute_url }}" class="game-title">{{ game.name }}</a>
+    {% if not game.change_for %}
+      <a href="{{ game.get_absolute_url }}" class="game-title">{{ game.name }}</a>
+    {% else %}
+      <a class="game-title">[Change suggestions for] {{ game.change_for.name }}</a>
+    {% endif %}
     {% for platform in game.platforms.all %}
       <a href="{% url "games_by_plaform" slug=platform.slug %}" class="filter-link">{{ platform }}</a>
     {% endfor %}


### PR DESCRIPTION
This tweaks a few settings in the `pylintrc` file, adds targets to `make` to lint quickly, and adds the linting target to Travis.

**Changes summed up**

- Restructured `pylintrc` a bit: I had the newest version generate a new one and structured it like that. Future diffs should be more easy now, but this diff looks like a mess now because of this
- Don't ignore settings: Setting files are also source-code files and should therefore be linted as well. Auto generated migrations are okay to exclude
- New make target: `make lint-python` to lint python code only
- New make target: `make lint` to lint every language (If less linter, html linter, Typescript linter etc are integrated in the future)
- Max line width: from 90 to 100 characters
- Use `pylint_django` plugin to improve Django-related linting
- Add an exception for method names if they start with `test_` (no max method length for unit tests - long names are actually encouraged here to precisely describe the test)

**Notes**

There are some pretty harsh ignores going on in the pylint file. I personally wouldn't ignore *any* error, I would enforce docstrings and disallow wildcard imports. I also wouldn't ignore R's and I's since it's often worth reconsidering a few structuring decisions. They're not always appropriate, yes, but disables can be added individually for that purpose on a per-file basis or even more finer.

I would be happy to address the above mentioned points if you agree with me.

**Future work**

If the changes to the `pylintrc` file are okay, I would proceed to refactor the code to make the CI pass.