### PR TITLE
Distinguish Debian instructions from Ubuntu

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -22,14 +22,39 @@
             <img src='{{ STATIC_URL }}images/icons/ubuntu.png' alt='Ubuntu'>Ubuntu
           </li>
           <li>
-            <img src='{{ STATIC_URL }}images/icons/debian.png' alt='Debian'>Debian
+            <img src='{{ STATIC_URL }}images/icons/pop_os.png' alt='Pop!_OS'>Pop!_OS
+          </li>
+          <li>
+            <img src='{{ STATIC_URL }}images/icons/elementary_os.png' alt='Elementary OS'>Elementary OS
           </li>
           <li>
             <img src='{{ STATIC_URL }}images/icons/linux_mint.png' alt='Linux Mint'>Linux Mint
           </li>
         </ul>
         <p>
-          Packages compatible with Debian and Ubuntu are available on the
+          Packages compatible with Ubuntu and Ubuntu derivatives are available on the
+          <a href="https://software.opensuse.org/download.html?project=home%3Astrycore&package=lutris">openSUSE Build Service</a>.
+          <br/>
+          You can add a repository to receive automatic updates:<br/>
+          <br/>
+          <strong>For Ubuntu & derivatives like Pop!_OS, Elementary OS, Linux Mint…</strong><br/>
+          <code>ver=$(lsb_release -sr); if [ $ver != "18.04" -a $ver != "17.10" -a $ver != "17.04" -a $ver != "16.04" ]; then ver=18.04; fi</code>
+          <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
+          <code>wget -q http://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/Release.key -O- | sudo apt-key add -</code><br/>
+          <br/>
+          <strong>After setting up the repository</strong><br/>
+          <code>sudo apt-get update</code><br/>
+          <code>sudo apt-get install lutris</code>
+        </p>
+      </li>
+      <li>
+        <ul>
+          <li>
+            <img src='{{ STATIC_URL }}images/icons/debian.png' alt='Debian'>Debian
+          </li>
+        </ul>
+        <p>
+          Packages compatible with Debian are available on the
           <a href="https://software.opensuse.org/download.html?project=home%3Astrycore&package=lutris">openSUSE Build Service</a>.
           <br/>
           You can add a repository to receive automatic updates:<br/>
@@ -37,11 +62,6 @@
           <strong>For Debian</strong><br/>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_9.0/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q http://download.opensuse.org/repositories/home:/strycore/Debian_9.0/Release.key -O- | sudo apt-key add -</code><br/>
-          <br/>
-          <strong>For Ubuntu & derivatives like Pop!_OS, Elementary OS, Linux Mint…</strong><br/>
-          <code>ver=$(lsb_release -sr); if [ $ver != "18.04" -a $ver != "17.10" -a $ver != "17.04" -a $ver != "16.04" ]; then ver=18.04; fi</code>
-          <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
-          <code>wget -q http://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/Release.key -O- | sudo apt-key add -</code><br/>
           <br/>
           <strong>After setting up the repository</strong><br/>
           <code>sudo apt-get update</code><br/>


### PR DESCRIPTION
Currently causes confusion like dude in this video: https://www.youtube.com/watch?v=ImL7bBYVhTY&t=2m16s

<details>
<summary>Which is preferred?</summary>
<br/>
Proposed change:

![downloads-page](https://user-images.githubusercontent.com/15083452/44329819-50698e00-a41a-11e8-8ecc-fb93f4f6bf49.png)

Or this one:

![downloads-page2](https://user-images.githubusercontent.com/15083452/44329862-6b3c0280-a41a-11e8-8257-70bc81e3b898.png)
</details>