### PR TITLE
Fix the Arch Link on the Downloads Page

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -70,8 +70,8 @@
           </li>
         </ul>
         <p>
-        You can get Lutris from the AUR repositories:
-        <a href="https://www.archlinux.org/packages/?q=lutris">https://www.archlinux.org/packages/lutris</a>.<br/>
+        You can get Lutris from the Arch Community Repository:
+        <a href="https://www.archlinux.org/packages/community/any/lutris/">https://www.archlinux.org/packages/community/any/lutris/</a>.<br/>
         </p>
       </li>
       <li>


### PR DESCRIPTION
Arch now hosts lutris in the community repos, and the AUR version is no longer supported. Also the current link is broken.  I have updated the downloads page to reflect this.