### PR TITLE
Security: Use HTTPS urls

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -28,7 +28,7 @@ class Downloads(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(Downloads, self).get_context_data(**kwargs)
         context['version'] = settings.CLIENT_VERSION
-        context['download_url'] = 'http://lutris.net/releases/'
+        context['download_url'] = 'https://lutris.net/releases/'
         return context
 
 

--- a/emails/messages.py
+++ b/emails/messages.py
@@ -43,6 +43,6 @@ def send_email(template, context, subject, recipients, sender=None):
         from_email=sender
     )
     html_body = render_to_string('emails/{}.html'.format(template), context)
-    html_part = transform(html_body, base_url='http://lutris.net')
+    html_part = transform(html_body, base_url='https://lutris.net')
     msg.attach_alternative(html_part, "text/html")
     return msg.send(False)

--- a/games/util/steam.py
+++ b/games/util/steam.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from common.util import slugify
 
 LOGGER = logging.getLogger(__name__)
-STEAM_API_URL = "http://api.steampowered.com/"
+STEAM_API_URL = "https://api.steampowered.com/"
 
 
 def get_capsule(steamid):

--- a/templates/common/about.html
+++ b/templates/common/about.html
@@ -187,7 +187,7 @@
       </p>
       <p>
         You can find some development information on the
-        <a href="http://wiki.lutris.net/index.php">wiki</a> and get a grasp of
+        <a href="https://github.com/lutris/lutris/wiki">wiki</a> and get a grasp of
         some of the features worked on and to come on our
         <a href="https://trello.com/b/jMe6TGr3/lutris">Trello board</a>.
       </p>

--- a/templates/common/about.html
+++ b/templates/common/about.html
@@ -181,7 +181,7 @@
       </p>
       <p>
         To discuss development you can subscribe to our
-        <a href="http://lists.lutris.net/cgi-bin/mailman/listinfo/lutris">mailing list</a>
+        <a href="https://lists.lutris.net/cgi-bin/mailman/listinfo/lutris">mailing list</a><!-- fixme: dead? -->
         and join us on IRC: <br/>
         <a href="irc://irc.freenode.org:6667/lutris">#lutris on freenode.org</a>
       </p>

--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -179,7 +179,7 @@
     </ul>
     <p class="footnote right">
     Icons by
-    <a href='http://www.fatcow.com/free-icons'>FatCow</a> under
+    <a href='https://www.fatcow.com/free-icons'>FatCow</a> under
     <a href="https://creativecommons.org/licenses/by/3.0/us/">CC-BY-3.0-US</a>
     </p>
   </div>

--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -50,7 +50,7 @@
           <strong>For Ubuntu & derivatives like Pop!_OS, Elementary OS, Linux Mint…</strong><br/>
           <code>ver=$(lsb_release -sr); if [ $ver != "18.04" -a $ver != "16.04" ]; then ver=18.04; fi</code>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
-          <code>wget -q http://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/Release.key -O- | sudo apt-key add -</code><br/>
+          <code>wget -q https://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/Release.key -O- | sudo apt-key add -</code><br/>
           <br/>
           <strong>After setting up the repository</strong><br/>
           <code>sudo apt-get update</code><br/>
@@ -71,7 +71,7 @@
           <br/>
           <strong>For Debian</strong><br/>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_9.0/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
-          <code>wget -q http://download.opensuse.org/repositories/home:/strycore/Debian_9.0/Release.key -O- | sudo apt-key add -</code><br/>
+          <code>wget -q https://download.opensuse.org/repositories/home:/strycore/Debian_9.0/Release.key -O- | sudo apt-key add -</code><br/>
           <br/>
           <strong>After setting up the repository</strong><br/>
           <code>sudo apt-get update</code><br/>
@@ -112,7 +112,7 @@
         </ul>
         <p>
         Lutris is available in Mageia App Db:
-        <a href="http://madb.mageia.org/package/show/name/lutris">http://madb.mageia.org/package/show/name/lutris</a>.<br/>
+        <a href="https://madb.mageia.org/package/show/name/lutris">https://madb.mageia.org/package/show/name/lutris</a>.<br/>
         </p>
       </li>
       <li>


### PR DESCRIPTION
Basically it seems like a good idea not to encourage users to download apt keys and tarballs over plaintext HTTP, when they're all available over HTTPS anyway.

I haven't run any tests on this.  I'm a bit unsure about the API stuff, but the first few commits are trivial and should hopefully be pretty uncontroversial.  I dunno about the last one (the link to the apparently-defunct lists.lutris.net).

Caveat: I'm not a regular Lutris user (haven't even installed it yet; the install instructions prompted me to make these changes), and I might take me a while to follow up.  Feel free to edit/merge as you see fit.