### PR TITLE
Add a line break between the first and second Ubuntu code blocks to fix copy-paste

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -48,7 +48,7 @@
           You can add a repository to receive automatic updates:<br/>
           <br/>
           <strong>For Ubuntu & derivatives like Pop!_OS, Elementary OS, Linux Mint…</strong><br/>
-          <code>ver=$(lsb_release -sr); if [ $ver != "18.10" -a $ver != "18.04" -a $ver != "16.04" ]; then ver=18.04; fi</code>
+          <code>ver=$(lsb_release -sr); if [ $ver != "18.10" -a $ver != "18.04" -a $ver != "16.04" ]; then ver=18.04; fi</code><br/>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q https://download.opensuse.org/repositories/home:/strycore/xUbuntu_$ver/Release.key -O- | sudo apt-key add -</code><br/>
           <br/>


### PR DESCRIPTION
Add a `<br/>` between the 1st and 2nd `<code/>` blocks to match there being a `<br/>` between the 2nd and 3rd `<code/>` blocks.

In Chrome, double clicking the first `<code/>` block would also select the contents of the second `<code/>` block because there was no `<br/>` between those 2 blocks. Copying then running the first 2 blocks together on the same line won't work because there is no semicolon after the `fi` at the end of the first line. This change fixes double click selection for copy-paste running the Ubuntu commands.