### PR TITLE
Replace the package link with install command for Arch

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -117,8 +117,8 @@
           </li>
         </ul>
         <p>
-        You can get Lutris from the Arch Community Repository:
-        <a href="https://www.archlinux.org/packages/community/any/lutris/">https://www.archlinux.org/packages/community/any/lutris/</a>.<br/>
+          You can get Lutris from the Arch Community Repository<br/>
+          <code>sudo pacman -S lutris</code>
         </p>
       </li>
       <li>


### PR DESCRIPTION
It makes more sense, I think.