### PR TITLE
Utilized Steam's "my" alias

### DIFF
--- a/templates/accounts/profile.html
+++ b/templates/accounts/profile.html
@@ -68,7 +68,7 @@
       </p>
       <p class="warning-message">
         Make sure to set <strong>both</strong> your Steam profile and the games
-        details set to public in your Steam account settings (available at <code>https://steamcommunity.com/profiles/<strong>&lt;your_steam_id&gt;</strong>/edit/settings</code>).
+        details set to public in your Steam account settings (available at <a href="https://steamcommunity.com/my/edit/settings">My Privacy Settings</a>).
         <a data-lightbox="steam-profile"
           data-title="Check both checkboxes in your Steam profile"
           href='{% static 'images/screenshots/steam-profile.png' %}'>See how</a>


### PR DESCRIPTION
Utilized Steam's "my" alias when pointing user to set both their Steam profile and the games details to public in the Steam account settings in Lutris website account management page.