### PR TITLE
Add missing functionality for suggesting publisher/developer (Fixes #250)

### DIFF
--- a/games/models.py
+++ b/games/models.py
@@ -168,8 +168,11 @@ class Game(models.Model):
         ("protected", "Installer modification is restricted"),
     )
 
-    # Those fields in the model are editable by the user
-    TRACKED_FIELDS = ["name", "year", "platforms", "genres", "website", "description", "title_logo"]
+    # These model fields are editable by the user
+    TRACKED_FIELDS = [
+        "name", "year", "platforms", "genres", "publisher", "developer",
+        "website", "description", "title_logo"
+    ]
 
     name = models.CharField(max_length=200)
     slug = models.SlugField(unique=True, null=True, blank=True)
@@ -265,10 +268,15 @@ class Game(models.Model):
         return {
             "name": self.name,
             "year": self.year,
-            "website": self.website,
-            "description": self.description,
             "platforms": [x.id for x in list(self.platforms.all())],
             "genres": [x.id for x in list(self.genres.all())],
+
+            # The Select2 dropdowns want ids instead of complete models
+            "publisher": self.publisher.id if self.publisher else None,
+            "developer": self.developer.id if self.developer else None,
+
+            "website": self.website,
+            "description": self.description,
             "title_logo": self.title_logo,
         }
 
@@ -303,6 +311,8 @@ class Game(models.Model):
         self.year = change_set.year
         self.platforms.set(change_set.platforms.all())
         self.genres.set(change_set.genres.all())
+        self.publisher = change_set.publisher
+        self.developer = change_set.developer
         self.website = change_set.website
         self.description = change_set.description
         self.title_logo = change_set.title_logo

--- a/games/tests/factories.py
+++ b/games/tests/factories.py
@@ -128,3 +128,11 @@ class InstallerFactory(factory.DjangoModelFactory):
     version = 'test'
     published = True
     user = factory.SubFactory(UserNoLibraryFactory)
+
+
+class CompanyFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = models.Company
+        django_get_or_create = ('name',)
+    name = factory.Iterator(['Valve', 'CD Projekt', 'Blizzard', 'Tripwire Interactive'])
+    slug = factory.Iterator(['valve', 'cd-projekt', 'blizzard', 'tripwire-interactive'])

--- a/games/tests/test_forms.py
+++ b/games/tests/test_forms.py
@@ -90,6 +90,8 @@ class TestGameEditForm(TestCase):
 
     def setUp(self):
         name = 'Horribly Misspelled Game Title'
+        developer = factories.CompanyFactory()
+        publisher = factories.CompanyFactory()
         platform = factories.PlatformFactory()
         genre = factories.GenreFactory()
         year = 2012
@@ -101,10 +103,14 @@ class TestGameEditForm(TestCase):
         self.game.website = website
         self.game.year = year
         self.game.description = ''
+        self.game.developer = developer
+        self.game.publisher = publisher
         self.game.save()
 
         self.inputs = {
             'name': name,
+            'developer': developer.id,
+            'publisher': publisher.id,
             'platforms': [platform.id],
             'genres': [genre.id],
             'website': website,


### PR DESCRIPTION
This fixes #250. It adds the functionality that was missing for the publisher/developer suggesting ("Suggest changes" form) to work. Now the form will correctly populate those fields with the existing company, as well as save what the user submitted (and allow moderators to approve/apply those changes).

Tested it locally and everything works fine.