### PR TITLE
Update install command for Clear Linux OS

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -124,8 +124,8 @@
           <li><img src="{{STATIC_URL}}images/icons/clearlinux.png" alt="Solus">Clear Linux</li>
         </ul>
         <p>
-          Lutris is available in the games bundle.<br/><br/>
-          <code>sudo swupd bundle-add games</code>
+          Lutris is available as a bundle.<br/><br/>
+          <code>sudo swupd bundle-add lutris</code>
         </p>
       </li>
       <li>


### PR DESCRIPTION
lutris has been split out into it's own bundle on Clear Linux OS and no longer has to be installed through the larger games bundle.

https://github.com/clearlinux/clr-bundles/commit/d840ae89110afa4e480f4eeb0d2bb7dc337ebca5