### PR TITLE
game_list.html: fix wrong form submission url when platform is selected

### DIFF
--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -33,7 +33,7 @@
 
         <!-- GENERAL FILTER, SEARCH -->
         <h4>Filter</h4>
-        <form action="." method="get" class="form-inline">
+        <form action="{% url 'game_list' %}" method="get" class="form-inline">
           <div class="input-group">
             <input type="text" name="q" class="search-query form-control"
                 placeholder="Search…" value="{{ search_terms|default:"" }}" />


### PR DESCRIPTION
If you select a platform, then select some filters and apply them,
the form will be submitted to `/games/platform/?[...]` instead of
`/games/?[...]`, which will result in a 404 page.

This is untested because one of the deps wants a package not in my distro and I don't feel like dealing with docker. Please review with care