### PR TITLE
Precache banners and icons on save

### DIFF
--- a/games/forms.py
+++ b/games/forms.py
@@ -148,7 +148,7 @@ class GameForm(forms.ModelForm):
         else:
             if game.is_public:
                 msg = (
-                    "This game is <a href='/games/%s'>already in our " "database</a>."
+                    "This game is <a href='/games/%s'>already in our database</a>."
                 ) % slug
             else:
                 msg = (
@@ -257,7 +257,7 @@ class ScreenshotForm(forms.ModelForm):
 
     def save(self, commit=True):
         self.instance.game = self.game
-        return super(ScreenshotForm, self).save(commit=commit)
+        return super().save(commit=commit)
 
 
 class InstallerForm(forms.ModelForm):

--- a/games/management/commands/resize_media.py
+++ b/games/management/commands/resize_media.py
@@ -1,62 +1,19 @@
 """Resize all game banners to a fixed size"""
 import os
-import shutil
 from django.core.management.base import BaseCommand
 from django.conf import settings
-from sorl.thumbnail import get_thumbnail
 from games.models import Game
 
 
 class Command(BaseCommand):
     """Resize banners and icons"""
 
-    ICON_PATH = os.path.join(settings.MEDIA_ROOT, "game-icons/128")
-    BANNER_PATH = os.path.join(settings.MEDIA_ROOT, "game-banners/184")
-
-    def resize_icon(self, game):
-        """Resize icon to fixed size"""
-        dest_file = os.path.join(self.ICON_PATH, "%s.png" % game.slug)
-        if os.path.exists(dest_file):
-            return
-        thumbnail = get_thumbnail(
-            game.icon,
-            settings.ICON_SIZE,
-            crop="center",
-            format="PNG"
-        )
-        shutil.copy(os.path.join(settings.MEDIA_ROOT, thumbnail.name), dest_file)
-
-    def resize_banner(self, game):
-        """Resize banner to fixed size"""
-        dest_file = os.path.join(self.BANNER_PATH, "%s.jpg" % game.slug)
-        if os.path.exists(dest_file):
-            return
-        thumbnail = get_thumbnail(
-            game.title_logo,
-            settings.BANNER_SIZE,
-            crop="center"
-        )
-        shutil.copy(os.path.join(settings.MEDIA_ROOT, thumbnail.name), dest_file)
-
     def handle(self, *args, **_kwargs):
         """Run command"""
-        if not os.path.exists(self.ICON_PATH):
-            os.makedirs(self.ICON_PATH)
-        if not os.path.exists(self.BANNER_PATH):
-            os.makedirs(self.BANNER_PATH)
+        if not os.path.exists(Game.ICON_PATH):
+            os.makedirs(Game.ICON_PATH)
+        if not os.path.exists(Game.BANNER_PATH):
+            os.makedirs(Game.BANNER_PATH)
 
-        games = Game.objects.all()
-        for game in games:
-            icon_path = os.path.join(settings.MEDIA_ROOT, game.icon.name)
-            if game.icon.name:
-                if not os.path.exists(icon_path):
-                    print("%s is missing icon" % game)
-                else:
-                    self.resize_icon(game)
-
-            banner_path = os.path.join(settings.MEDIA_ROOT, game.title_logo.name)
-            if game.title_logo.name:
-                if not os.path.exists(banner_path):
-                    print("%s is missing banner" % game)
-                else:
-                    self.resize_banner(game)
+        for game in Game.objects.all():
+            game.precache_media()

--- a/lutrisweb/settings/base.py
+++ b/lutrisweb/settings/base.py
@@ -68,7 +68,7 @@ FILES_ROOT = media_directory('files')
 FILES_URL = 'http://%s/media/files/' % DOMAIN_NAME
 
 TOSEC_PATH = media_directory('tosec')
-TOSEC_DAT_PATH = os.path.join(TOSEC_PATH)
+TOSEC_DAT_PATH = TOSEC_PATH
 
 GOG_LOGO_PATH = os.path.join(BASE_DIR, 'gog-logos')
 GOG_LUTRIS_LOGO_PATH = os.path.join(BASE_DIR, 'gog-lutris-logos')


### PR DESCRIPTION
The game and icons are currently served as static folders to avoid making database queries to Sorl tables for each media.
This makes sure the media are created/updated on each save.