### PR TITLE
Make the installation steps more user friendly

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -43,7 +43,7 @@
         <p>
           Packages compatible with Ubuntu and derivatives are available on the
           <a href="https://launchpad.net/~lutris-team/+archive/ubuntu/lutris">PPA</a>.<br/>
-          You can add a repository to receive automatic updates:<br/>
+          You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
           <code>sudo add-apt-repository ppa:lutris-team/lutris</code><br/>
           <code>sudo apt-get update</code><br/>
@@ -61,7 +61,7 @@
           Packages compatible with Debian are available on the
           <a href="https://software.opensuse.org/download.html?project=home%3Astrycore&package=lutris">openSUSE Build Service</a>.
           <br/>
-          You can add a repository to receive automatic updates:<br/>
+          You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_10/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q https://download.opensuse.org/repositories/home:/strycore/Debian_10/Release.key -O- | sudo apt-key add -</code><br/>


### PR DESCRIPTION
Mention that the commands for adding repository should be pasted into terminal. Not every (beginner) user knows that these are commands that should be pasted into terminal.

/cc @strycore