### PR TITLE
Bugfix: Allow loading first revision

### DIFF
--- a/templates/installers/form.html
+++ b/templates/installers/form.html
@@ -23,7 +23,7 @@
       <p>Load a previous revision </p>
       <select class='django-select2' id='revision-select'>
         {% for version in versions %}
-        <option value="{{version.id}}">{{version.revision.comment}}</option>
+        <option value="{{version.id}}" {% if version.id == revision_id %}selected{% endif %}>{{version.revision.comment}}</option>
         {% endfor %}
       </select>
     {% endif %}


### PR DESCRIPTION
In my opinion, the context people normally put in PRs really belongs in the commit message. Copied here for convenience:

> Changing this selection (re)loads the page with the selected revision.
> This is triggered only when the selection actually changes (on Firefox,
> at least); if you just select the current revision, there is no reload.
> This is good, since a reload would be unnecessary.
> 
> However, currently the first entry is always selected by default,
> regardless of which revision is actually loaded / shown on page. This
> makes it impossible to return to the first entry once you've left: in
> order to do that, you'd need to switch off of it and then back on, but
> switching off loads that revision and reloads the page with the first
> entry selected again.
> 
> This commit changes the default selection to be the currently shown
> revision, so it's possible to change back to the first one.

**Important notes:**

- I don't work much with python and this is my first time touching django.
- I haven't gotten the site running locally or tested this in any way. I noticed the bug while looking into something else and setting up a python environment / docker is a lot of effort relative to writing the 4-line patch.

So I would appreciate a thorough review of this tiny patch. Let me know if you'd like me to change the indentation or move the `if` inside the `<option>` tag.