### PR TITLE
Keep draft 'reason' when editing own draft

### DIFF
--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -294,6 +294,7 @@ def edit_installer(request, slug):
         revision_id = None
 
     draft_data = None
+    selected_version = None
     versions = Version.objects.get_for_object(installer)
 
     # Reset reason when the installer is edited.
@@ -303,20 +304,25 @@ def edit_installer(request, slug):
         if revision_id:
             # Display the revision given in the GET parameters
             if version.revision.id == revision_id:
-                draft_data = version.field_dict
+                selected_version = version
                 break
         else:
             # Display the latest revision created by the current logged in user
             if (
                     version.revision.user == request.user or request.user.is_staff
             ) and version.revision.date_created > installer.updated_at:
-                draft_data = version.field_dict
+                selected_version = version
                 revision_id = version.revision.id
                 break
-    if draft_data:
-        draft_data["reason"] = ""
-        if "runner_id" in draft_data:
-            draft_data["runner"] = draft_data["runner_id"]
+
+    if selected_version:
+        draft_data = version.field_dict
+        if draft_data:
+            if "runner_id" in draft_data:
+                draft_data["runner"] = draft_data["runner_id"]
+            # Reset reason only if user is building on someone else's draft
+            if version.revision.user != request.user:
+                draft_data["reason"] = ""
 
     form = InstallerEditForm(
         request.POST or None, instance=installer, initial=draft_data


### PR DESCRIPTION
Fixes the following bug:

- Start editing an installer
- Write something in the 'Reason' field
- Save a draft

Expected: All fields stay the same
Actual: 'Reason' field gets reset to empty, so I need to re-type it before submitting

At least one person has been re-writing the reason *every time* they save a draft (<https://discordapp.com/channels/512538904872747018/546612632027922452/721809136232431647>), and I'm sure there's others who submit with blank reasons, not realizing it disappeared.

This behavior was introduced with 2ecfe2c, which was itself a bugfix for https://github.com/lutris/website/issues/167, so we need to take care not to reintroduce it.

This is a draft because:

- It's kind of ugly code. I'd like to try and find a more elegant way to rearrange things.
- I have not tested it. I'd like to get the lutris site running locally and do this.
- Bad commit message. I'd like to clean up this PR text and include it there.

I haven't done these because I need to get to work :laughing:; I'll get back to this later (this weekend?), unless someone else wants to pick it up.