### PR TITLE
Show useful info after a "successful" search

### DIFF
--- a/templates/games/game_list.html
+++ b/templates/games/game_list.html
@@ -53,11 +53,23 @@
 <div class="row">
   <div class="col-sm-9">
     {% if games %}
-    <ul class="game-list">
-      {% for game in games %}
-        {% include "includes/game_preview.html" %}
-      {% endfor %}
-    </ul>
+      <ul class="game-list">
+	{% for game in games %}
+	  {% include "includes/game_preview.html" %}
+	{% endfor %}
+      </ul>
+      <div class="filter-failure-message">
+        <p>Didn't find what you're looking for?</p>
+        {% if unpublished_filter %}
+          <p>
+            Feel free to <a href="{% url 'game-submit' %}">add the game</a> to our database.
+          </p>
+        {% else %}
+          <p>
+            Try looking in unpublished games. 
+          </p>
+        {% endif %}
+      </div>
     {% else %}
       <div class="filter-failure-message">
         <p class="filter-failure-icon">


### PR DESCRIPTION
Added some text that points the user towards the "Show unpublished" option after a "successful" search, and, if that option is already ticked, it links them to the game creation page.
I feel this is needed because even if a search returns some results, those results might not be what you're looking for, in which case you might not be aware of these possibilities.
For example, I was looking for "Of orcs and men", which isn't published. However, since "Styx: Master of Shadows" mentions it in its description, I wasn't made aware of the existence of unpublished games, or of the game creation page, and I had to look for help in the discord channel.
I think this patch is a good way to deal with cases like that.