### PR TITLE
Update Ubuntu/Debian install instructions

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -45,9 +45,9 @@
           <a href="https://launchpad.net/~lutris-team/+archive/ubuntu/lutris">PPA</a>.<br/>
           You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
-          <code>sudo add-apt-repository ppa:lutris-team/lutris</code><br/>
-          <code>sudo apt-get update</code><br/>
-          <code>sudo apt-get install lutris</code><br/><br/>
+          <code>sudo apt add-repository ppa:lutris-team/lutris</code><br/>
+          <code>sudo apt update</code><br/>
+          <code>sudo apt install lutris</code><br/><br/>
           Lutris is now available on Pop!_OS through <a href="appstream://net.lutris.Lutris">Pop!_Shop</a>.
         </p>
       </li>
@@ -65,8 +65,8 @@
           <br/>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_10/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q https://download.opensuse.org/repositories/home:/strycore/Debian_10/Release.key -O- | sudo apt-key add -</code><br/>
-          <code>sudo apt-get update</code><br/>
-          <code>sudo apt-get install lutris</code>
+          <code>sudo apt update</code><br/>
+          <code>sudo apt install lutris</code>
         </p>
       </li>
       <li>

--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -45,9 +45,9 @@
           <a href="https://launchpad.net/~lutris-team/+archive/ubuntu/lutris">PPA</a>.<br/>
           You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
-          <code>sudo apt add-repository ppa:lutris-team/lutris</code><br/>
-          <code>sudo apt update</code><br/>
-          <code>sudo apt install lutris</code><br/><br/>
+          <code>apt add-repository ppa:lutris-team/lutris</code><br/>
+          <code>apt update</code><br/>
+          <code>apt install lutris</code><br/><br/>
           Lutris is now available on Pop!_OS through <a href="appstream://net.lutris.Lutris">Pop!_Shop</a>.
         </p>
       </li>
@@ -65,8 +65,8 @@
           <br/>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_10/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q https://download.opensuse.org/repositories/home:/strycore/Debian_10/Release.key -O- | sudo apt-key add -</code><br/>
-          <code>sudo apt update</code><br/>
-          <code>sudo apt install lutris</code>
+          <code>apt update</code><br/>
+          <code>apt install lutris</code>
         </p>
       </li>
       <li>


### PR DESCRIPTION
Replaced "apt-get" to "apt" since apt has a cleaner output and color support.