### PR TITLE
Fix command to add Lutris PPA

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -48,7 +48,7 @@
           <a href="https://launchpad.net/~lutris-team/+archive/ubuntu/lutris">PPA</a>.<br/>
           You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
-          <code>sudo apt add-apt-repository ppa:lutris-team/lutris</code><br/>
+          <code>sudo add-apt-repository ppa:lutris-team/lutris</code><br/>
           <code>sudo apt update</code><br/>
           <code>sudo apt install lutris</code><br/><br/>
           Lutris is now available on Pop!_OS through <a href="appstream://net.lutris.Lutris">Pop!_Shop</a>.


### PR DESCRIPTION
This corrects the command to add the Lutris PPA for Ubuntu-based distributions by removing the invalidating `apt` in the first line of the instructions.