### PR TITLE
Change the home page game banners order hourly

### DIFF
--- a/common/views.py
+++ b/common/views.py
@@ -9,6 +9,8 @@ from django.urls import reverse
 from common.forms import UploadForm
 from common.models import News
 from games.models import Game, Installer
+import random
+import datetime as dt
 
 
 def home(request):
@@ -23,10 +25,51 @@ def home(request):
             .order_by('-updated_at')
         )[:6]
     ]
+    samples = [
+        {
+            "image": "images/carousel/overwatch.jpg",
+            "href": "/games/overwatch",
+            "text": "Play Overwatch on Battle.net",
+        },
+        {
+            "image": "images/carousel/the-witcher.jpg",
+            "href": "/games/the-witcher-3-wild-hunt",
+            "text": "Install The Witcher 3 from GOG or Steam",
+        },
+        {
+            "image": "images/carousel/warframe.jpg",
+            "href": "/games/warframe",
+            "text": "Play Warframe",
+        },
+        {
+            "image": "images/carousel/battlefield5.jpg",
+            "href": "/games/battlefield-v",
+            "text": "Play Battlefield V on Origin",
+        },
+        {
+            "image": "images/carousel/eso.jpg",
+            "href": "/games/the-elder-scrolls-online-tamriel-unlimited",
+            "text": "Play The Elders Scrolls: Online",
+        },
+        {
+            "image": "images/carousel/warcraft.jpg",
+            "href": "/games/world-of-warcraft",
+            "text": "Play World of Warcraft",
+        }
+    ]
+    random.shuffle(samples, shuffle_by_hour)
     return render(request, 'home.html', {
         "new_games": new_games,
-        "updated_games": updated_games
+        "updated_games": updated_games,
+        "sample_banners": samples
     })
+
+
+def shuffle_by_hour():
+    """
+    Converts the current hour into a float between 0.0 and 1.0 for use in shuffling arrays.
+    """
+    return dt.datetime.now().hour / 24
 
 
 class Downloads(TemplateView):

--- a/games/views/admin.py
+++ b/games/views/admin.py
@@ -42,7 +42,7 @@ def list_change_submissions_view(request, game_id=None):
         # Generate diff
         diff = change_suggestion.get_changes()
 
-        # If the diff is empty, this change is obselete and can be deleted
+        # If the diff is empty, this change is obsolete and can be deleted
         if not diff:
             change_suggestion.delete()
             obsolete_changes += 1

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,11 +16,11 @@
   <script defer src="https://use.fontawesome.com/releases/v5.2.0/js/all.js" integrity="sha384-4oV5EgaV02iISL2ban6c/RmotsABqE4yZxZLcYMAdG7FAPsyHYAPpywE9PJo+Khy" crossorigin="anonymous"></script>
   {% block stylesheets %}{% endblock %}
   {% block extra_head %}{% endblock %}
+  <style>
+    a.title:link {text-decoration:none;}
+    a.title:hover {color:#ff9900;text-decoration:underline;}
+  </style>
 </head>
-<style>
-  a.title:link {text-decoration:none;}
-  a.title:hover {color:#ff9900;text-decoration:underline;}
-</style>
 <body>
   {% if messages %}
   <ul class="alerts">

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,36 +8,13 @@
 <script src="{% static 'jssor/js/jssor.slider.min.js' %}"></script>
 <div id="jssor_1" style="position:relative;margin:0 auto;top:0px;left:0px;width:1280px;height:720px;overflow:hidden;visibility:hidden;">
   <div data-u="slides" style="cursor:default;position:relative;top:0px;left:0px;width:1280px;height:720px;overflow:hidden;">
-    <div style="background: url('{% static 'images/carousel/overwatch.jpg' %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
-      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/overwatch">
-        Play Overwatch on Battle.net
+    {% for sample in sample_banners %}
+    <div style="background: url('{% static sample.image %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
+      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="{{ sample.href }}">
+        {{ sample.text }}
       </a>
     </div>
-    <div style="background: url('{% static 'images/carousel/the-witcher.jpg' %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
-      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/the-witcher-3-wild-hunt">
-        Install The Witcher 3 from GOG or Steam
-      </a>
-    </div>
-    <div style="background: url('{% static 'images/carousel/warframe.jpg' %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
-      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/warframe">
-        Play Warframe
-      </a>
-    </div>
-    <div style="background: url('{% static 'images/carousel/battlefield5.jpg' %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
-      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/battlefield-v">
-        Play Battlefield V on Origin
-      </a>
-    </div>
-    <div style="background: url('{% static 'images/carousel/eso.jpg' %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
-      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/the-elder-scrolls-online-tamriel-unlimited">
-        Play The Elders Scrolls: Online
-      </a>
-    </div>
-    <div style="background: url('{% static 'images/carousel/warcraft.jpg' %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
-      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/world-of-warcraft">
-        Play World of Warcraft
-      </a>
-    </div>
+    {% endfor %}
   </div>
   <div data-u="arrowleft" class="jssora093" style="width:50px;height:50px;top:0px;left:30px;" data-autocenter="2" data-scale="0.75" data-scale-left="0.75">
     <svg viewBox="0 0 16000 16000" style="position:absolute;top:0;left:0;width:100%;height:100%;">


### PR DESCRIPTION
I personally thought it was odd always seeing the Overwatch banner first whenever I visited Lutris.net. I thought that maybe it would give a fresh look to change the banner ordering randomly on an hourly basis (but for a whole hour it will stay in that order) to give these other "top-tier" games a chance. Tested it with the local dev environment and it worked fine.

![Screenshot from 2020-09-28 10-33-31](https://user-images.githubusercontent.com/521702/94446034-1e3cc580-0176-11eb-8ae7-e61d81df6c45.png)

Also fixed a typo, and moved a `<style>` block into the `<head>` to be more HTML compliant.

What do you think?