### PR TITLE
Enable OpenSearch Autodiscovery

### DIFF
--- a/public/xml/opensearch.xml
+++ b/public/xml/opensearch.xml
@@ -1,0 +1,7 @@
+<OpenSearchDescription>
+  <ShortName>Lutris</ShortName>
+  <Description>Find Games on Lutris</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">https://lutris.net/static/favicon.ico</Image>
+  <Url type="text/html" method="get" template="https://lutris.net/games?q={searchTerms}"/>
+</OpenSearchDescription>

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons">
   <link type="text/css" href="{% static 'css/libs.min.css' %}" rel="stylesheet" />
   <link type="text/css" href="{% static 'css/lutris.min.css' %}" rel="stylesheet" />
+  <link type="application/opensearchdescription+xml" href="{% static 'xml/opensearch.xml' %}" rel="search" title="Lutris">
   <script defer src="https://use.fontawesome.com/releases/v5.2.0/js/all.js" integrity="sha384-4oV5EgaV02iISL2ban6c/RmotsABqE4yZxZLcYMAdG7FAPsyHYAPpywE9PJo+Khy" crossorigin="anonymous"></script>
   {% block stylesheets %}{% endblock %}
   {% block extra_head %}{% endblock %}


### PR DESCRIPTION
Allow Lutris to be autodiscovered as a search engine by browsers

Spec: https://developer.mozilla.org/en-US/docs/Web/OpenSearch

EDIT: Let me know if you'd like a `&ref=opensearch` parameter or something similar to track usage of this feature.