### PR TITLE
Fix environment variable typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ worker:
 localdb:
 	# Create a local Postgres database for development
 	docker volume create lutrisdb_backups
-	docker run --name lutrisdb -e POSTGRES_PASSWORD=admin -e POSGRES_DB=lutris -e POSTGRES_USER=lutris -p 5432:5432 -d -v lutrisdb_backups:/backups --restart=unless-stopped postgres:12
+	docker run --name lutrisdb -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=lutris -e POSTGRES_USER=lutris -p 5432:5432 -d -v lutrisdb_backups:/backups --restart=unless-stopped postgres:12
 
 syncdb:
 	# Syncs the production database to the local db


### PR DESCRIPTION
The `make localdb` make target had `POSGRES_DB` in it, but in fact the correct env variable is `POSTGRES_DB` as seen on https://hub.docker.com/_/postgres

It likely went unnoticed since if you already had the `lutris` DB created you wouldn't know.

**This is NOT a bullshit Hacktoberfest Pull Request, I promise.** Just something I actually ran into when reference this code for another project I'm doing.