### PR TITLE
Change wording of link to Discord server in FAQ

### DIFF
--- a/templates/common/faq.html
+++ b/templates/common/faq.html
@@ -23,7 +23,7 @@
       <p>
         If you want to ask questions about Lutris or just hang out with other
         Lutris users, you can join the
-        <a href="{{ DISCORD_URL }}">#lutris channel on the Linux_Gamers_Group Discord</a>
+        <a href="{{ DISCORD_URL }}">Lutris Discord server</a>
         or our IRC channel
         <a href="irc://irc.freenode.org:6667/lutris">#lutris on freenode.org</a>.
         You can also use the <a href="https://forums.lutris.net/">forums</a> to ask questions.


### PR DESCRIPTION
Changed text since Lutris now has full Discord server and not just one channel