### PR TITLE
Update downloads.html

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -173,7 +173,7 @@
         <p>
         For CentOS Stream and derivatives like RHEL 8 You can clone
         <a href="https://github.com/jatin-cbs/Lutris-RHEL-CentOS-8">
-          this github repository</a> and then install cabextract and lutris:<br/><code>sudo dnf install cabextract-*.el8.x86_64.rpm lutris-*.el8.x86_64.rpm</code>
+          this github repository</a> and then install the lutris rpm package:<br/><code>sudo dnf install lutris-*.el8.x86_64.rpm</code>
 	  <br/>Note: Enable EPEL, you can follow the <a href="https://github.com/jatin-cbs/Lutris-RHEL-CentOS-8/blob/master/README.md">README </a>for more information.
         </p>
       </li>


### PR DESCRIPTION
- Cabextract is no longer needed from my repo due to it being included in EPEL by Rex :)

https://bugzilla.redhat.com/show_bug.cgi?id=1744725

