### PR TITLE
Fix ESO link

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -29,7 +29,7 @@
       </a>
     </div>
     <div style="background: url('{% static 'images/carousel/eso.jpg' %}') no-repeat center center fixed; background-size: cover; background-size: 100%;">
-      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/the-elder-scrolls-online-tamriel-unlimited">
+      <a data-t="0" class="slide-legend" data-events="auto" data-display="block" href="/games/the-elder-scrolls-online">
         Play The Elders Scrolls: Online
       </a>
     </div>


### PR DESCRIPTION
Correct link should be `/games/the-elder-scrolls-online`, the currently used `/games/the-elder-scrolls-online-tamriel-unlimited` returns 404.

/cc @strycore