### PR TITLE
Lutris is now in EPEL 8,9.

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -160,10 +160,8 @@
           </li>
         </ul>
         <p>
-        For CentOS Stream and derivatives like RHEL 8 or Rocky Linux 8 You can clone
-        <a href="https://github.com/jatin-cbs/Lutris-RHEL-CentOS-8">
-          this github repository</a> and then install the lutris rpm package:<br/><code>sudo dnf install lutris-*.el8.x86_64.rpm</code>
-	  <br/>Note: Enable EPEL, you can follow the <a href="https://github.com/jatin-cbs/Lutris-RHEL-CentOS-8/blob/master/README.md">README </a>for more information.
+        For CentOS Stream and derivatives like RHEL 8,9 or Rocky Linux 8,9 the package is available in EPEL (Extra packages for Enerprise Linux)
+	  <br/>Note: Enable EPEL, you can follow these <a href="https://docs.fedoraproject.org/en-US/epel/#_el9">instructions </a>for more information.
         </p>
       </li>
       <li>


### PR DESCRIPTION
Lutris is now in EPEL 8,9 :) Thanks Steve Cossette !. As a result the repo I used to maintain is no longer needed. Will mention this in my repo as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1758840