### PR TITLE
Update Debian installation instructions

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -67,7 +67,9 @@
           You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_11/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
-          <code>wget -q https://download.opensuse.org/repositories/home:/strycore/Debian_11/Release.key -O- | sudo apt-key add -</code><br/>
+          <code>wget -q
+            https://download.opensuse.org/repositories/home:/strycore/Debian_11/Release.key
+            -O- | sudo tee /etc/apt/trusted.gpg.d/lutris.asc -</code><br/>
           <code>sudo apt update</code><br/>
           <code>sudo apt install lutris</code>
         </p>


### PR DESCRIPTION
Replace the deprecated apt-key with one of the new methods of adding GPG
keys since apt-key is deprecated.

fixes: #619