### PR TITLE
Correct installation instructions for Steam Deck

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -42,11 +42,13 @@
           </li>
         </ul>
         <p>
-          <strong>To install Lutris on the Steam Deck:</strong><br>
+          <strong>To install Lutris on the Steam Deck via Flatpak:</strong><br>
           - Open the Power menu and select Switch to Desktop<br>
-          - Open Konsole and run the following command: <br>
+          - Open Konsole and run the following commands:<br>
+          <code>flatpak remote-add flathub-beta https://flathub.org/beta-repo/flathub-beta.flatpakrepo</code><br>
+          <code>flatpak update --appstream</code><br>
           <code>flatpak install flathub org.gnome.Platform.Compat.i386 org.freedesktop.Platform.GL32.default org.freedesktop.Platform.GL.default</code><br>
-          - Open Discover and search for Lutris then install it<br><br>
+          <code>flatpak install flathub-beta net.lutris.Lutris</code><br>
           <strong>To play games from the Steam Deck UI:</strong><br>
           Select "Create Steam shortcut" during the game installation or right-click on an existing game and choose "Create Steam shortcut".<br><br>
           <strong>To play games using the controller:</strong><br>


### PR DESCRIPTION
Clarify that Steam OS installation will use Flatpak and explicitly add instructions to enable and install Lutris from the Flathub beta.

The instructions currently listed do not work because the Flathub beta remote uses `no-enumerate`, so Lutris is not available in Discover. For system stability, it's probably best not to include instructions to enable enumeration on beta since many users unfamiliar with Flathub will only be interested in installing Lutris from the beta remote.