### PR TITLE
Update downloads page to not show RHEL version.

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -190,7 +190,7 @@
             <img src='{{ STATIC_URL }}images/icons/centos.png' alt='CentOS'>CentOS Stream
           </li>
           <li>
-            <img src='{{ STATIC_URL }}images/icons/redhat.png' alt='RHEL'>RHEL 8
+            <img src='{{ STATIC_URL }}images/icons/redhat.png' alt='RHEL'>RHEL
           </li>
         </ul>
         <p>


### PR DESCRIPTION
RHEL version should not be shown on the left, as its available in EPEL 8 and 9 both :)