### PR TITLE
Add link to Flathub

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -21,7 +21,7 @@
         system. This will provide all necessary dependency as Lutris cannot ship
         with every component in its <a href="https://github.com/lutris/docs/blob/master/LutrisRuntime.md">
         runtime</a>. When playing games lutris will use
-        a custom version of Wine optimized for games.<br>
+        a custom version of Wine optimized for games.<br/>
         This is not needed if running Lutris from Flatpak.
     </p>
     <ul class='download-list'>
@@ -44,14 +44,14 @@
         <p>
           To install Lutris on the Steam Deck, switch to Desktop Mode, open the Discover store
           then search and install Lutris.
-          <br>
+          <br/>
 
-          <strong>To play games from the Steam Deck UI:</strong><br>
-          Select "Create Steam shortcut" during the game installation or right-click on an existing game and choose "Create Steam shortcut".<br><br>
-          <strong>To play games using the controller:</strong><br>
-          - Open Steam settings and in the Controller section open Desktop Configuration<br>
-          - Change the controller configuration to Disabled<br>
-          - Keep the Steam key pressed to control your mouse<br>
+          <strong>To play games from the Steam Deck UI:</strong><br/>
+          Select "Create Steam shortcut" during the game installation or right-click on an existing game and choose "Create Steam shortcut".<br/><br/>
+          <strong>To play games using the controller:</strong><br/>
+          - Open Steam settings and in the Controller section open Desktop Configuration<br/>
+          - Change the controller configuration to Disabled<br/>
+          - Keep the Steam key pressed to control your mouse<br/>
           - The controller will now be accessible in desktop mode
         </p>
       </li>
@@ -62,7 +62,7 @@
           </li>
         </ul>
         <p>
-          Lutris is available in Flathub.<br>
+          Lutris is available in <a href="https://flathub.org/apps/details/net.lutris.Lutris">Flathub</a>.<br/>
           <code>flatpak install flathub net.lutris.Lutris</code>
         </p>
       </li>


### PR DESCRIPTION
Add link to Flathub + change the br tag to br/ that is preferred and used on the rest of the page.