### PR TITLE
Remove spurious - in the Debian instructions

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -96,7 +96,7 @@
           <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_11/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q
             https://download.opensuse.org/repositories/home:/strycore/Debian_11/Release.key
-            -O- | sudo tee /etc/apt/trusted.gpg.d/lutris.asc -</code><br/>
+            -O- | sudo tee /etc/apt/trusted.gpg.d/lutris.asc</code><br/>
           <code>sudo apt update</code><br/>
           <code>sudo apt install lutris</code>
         </p>


### PR DESCRIPTION
This spurious - causes a file named /etc/- to be created.