### PR TITLE
Use HTTPS for the opensuse.org Debian repo

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -93,7 +93,7 @@
           <br/>
           You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
-          <code>echo "deb http://download.opensuse.org/repositories/home:/strycore/Debian_11/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
+          <code>echo "deb https://download.opensuse.org/repositories/home:/strycore/Debian_11/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q
             https://download.opensuse.org/repositories/home:/strycore/Debian_11/Release.key
             -O- | sudo tee /etc/apt/trusted.gpg.d/lutris.asc -</code><br/>


### PR DESCRIPTION
HTTPS support is built-in since apt 1.6 (released 5 years ago).