### PR TITLE
add deb-get as tracking installation source

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -80,6 +80,22 @@
           A deb package is available from the release page on Github:
           <a href="https://github.com/lutris/lutris/releases">https://github.com/lutris/lutris/releases</a>
         </p>
+        <p>
+          <strong>Debian and Ubuntu based distros</strong>
+          <p>For users of Debian and Ubuntu based distributions, you can also
+          install and update the <code>.deb</code> package from the
+          GitHub release page using <a
+          href="https://github.com/wimpysworld/deb-get">deb-get</a>.</p>
+          <p>First install <code>deb-get</code> using these commands in a
+          terminal:</p>
+          <pre><code>sudo apt install curl
+          curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get</code></pre>
+          <p>Then install Lutris using the following command in terminal:</p>
+          <pre><code>deb-get install lutris</code></pre>
+          <p>Once Lutris is installed it can be kept up-to-date using:</p>
+          <pre><code>deb-get update
+          deb-get upgrade</code></pre>
+
       </li>
       <li>
         <ul>


### PR DESCRIPTION
wimpysworld/deb-get#579

This PR is part of a Hacktoberfest 2022 mini-event at the deb-get project to inform users of Lutris that for debian/ubuntu distros there is an easy way to install and update this popular tool.
With deb-get installed former user of the PPA can easily adopt a similar routine update practice tracking the latest github release of your project.

A pending PR there will shortly move the source from the deprecated unsupported PPA to track the github releases instead. This will potentially replace the simple and reliable up-to-date experience that former PPA users valued, and also extend it to debian and debian-derived distributions. (I referenced deb-get on #4296 and that refers to #4558 so the former PPA users who read issues will hopefully find out)


I hope you find this appropriate and valuable. Thanks.