### PR TITLE
add: new filter parameters to installers list api

### DIFF
--- a/games/views/games.py
+++ b/games/views/games.py
@@ -177,7 +177,7 @@ class GameStatsView(APIView):
             game__change_for__isnull=False,
         ).count()
         statistics["installers"] = models.Installer.objects.all().count()
-        statistics["published_installers"] = models.Installer.objects.published().count()
+        statistics["published_installers"] = models.Installer.objects.get_filtered({"published": True}).count()
         statistics["submitted_drafts"] = models.InstallerDraft.objects.filter(draft=False).count()
         statistics["drafts"] = models.InstallerDraft.objects.all().count()
         statistics["screenshots"] = models.Screenshot.objects.all().count()

--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -222,7 +222,7 @@ def game_detail(request, slug):
             LOGGER.error("The slug '%s' was used multiple times", slug)
             return redirect(reverse("game_detail", kwargs={"slug": games[0].slug}))
     user = request.user
-    installers = game.installers.published()
+    installers = game.installers.get_filtered({"published": True})
     provider_links = game.get_provider_links()
 
     pending_change_subm_count = 0


### PR DESCRIPTION
Supported query parameters:
        status: installer status (published, unpublished)
        revision: installer revision (draft, final)
        created_from: installer creation period start
        created_to: installer creation period end
        updated_from: installer modification period start
        updated_to: installer modification period end
        order: order results by creation date (oldest, newest), default=newest