### PR TITLE
Update Debian repository URL. Closes #679

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -103,9 +103,9 @@
           <br/>
           You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
-          <code>echo "deb https://download.opensuse.org/repositories/home:/strycore/Debian_11/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
+          <code>echo "deb https://download.opensuse.org/repositories/home:/strycore/Debian_12/ ./" | sudo tee /etc/apt/sources.list.d/lutris.list</code><br/>
           <code>wget -q
-            https://download.opensuse.org/repositories/home:/strycore/Debian_11/Release.key
+            https://download.opensuse.org/repositories/home:/strycore/Debian_12/Release.key
             -O- | sudo tee /etc/apt/trusted.gpg.d/lutris.asc</code><br/>
           <code>sudo apt update</code><br/>
           <code>sudo apt install lutris</code>


### PR DESCRIPTION
Updating Debian repo URLs for Debian 12, `bookworm`. Closes #679 