### PR TITLE
Reduce font size for anticheat disclaimer

### DIFF
--- a/frontend/css/_custom.scss
+++ b/frontend/css/_custom.scss
@@ -1069,7 +1069,7 @@ ol.toc a{
 .danger-zone {
   border: 4px solid red;
   background-color: rgb(255, 234, 195);
-  font-size: 1.4em;
+  font-size: 1em;
   padding: 8px;
   color: rgb(46, 11, 11);
 }


### PR DESCRIPTION
Currently, the disclaimer is a bit too large and takes up way too much space on the web page. This would make it a bit more compact and easier to view.