### PR TITLE
Provide proof of cheating in anticheat disclaimer

### DIFF
--- a/templates/games/detail.html
+++ b/templates/games/detail.html
@@ -75,7 +75,10 @@
         </p>
         <p>
           Although many publishers claim those anticheats are necessary to combat cheaters and keep the game competitive,
-          this is disproven by the fact that using such anticheat software has neither stopped such cheating from occurring
+          this is disproven by the fact that using such anticheat software has neither
+          <a href=https://www.vice.com/en/article/z3xjqa/cheat-maker-is-so-far-not-afraid-of-call-of-dutys-new-kernel-level-anti-cheat>
+            stopped such cheating from occurring
+          </a>
           nor prevented cheats from being easily distributed. In fact, there are a lot of games which are just as competitive
           and fun, but don't require complete control over your machine.
         </p>

--- a/templates/games/detail.html
+++ b/templates/games/detail.html
@@ -67,6 +67,7 @@
       <div class="danger-zone">
         <h3><strong>This game requires kernel-level anticheat software which is unsupported on Linux.</strong></h3>
         <p>
+          <br>
           This game's anticheat works at the kernel level, giving full control of your machine to the publisher,
           or anyone who manages to take control of the publisher. As there is no way of knowing exactly what this software does,
           running this game would require you to completely trust that the publisher will not abuse their power and are capable


### PR DESCRIPTION
The second paragraph in the disclaimer seems like an unfounded rumor, so adding a link to this article about a cheat maker talking about anti-cheat software should provide some legitimacy.

https://www.vice.com/en/article/z3xjqa/cheat-maker-is-so-far-not-afraid-of-call-of-dutys-new-kernel-level-anti-cheat

I also added a break just before the first paragraph.