### PR TITLE
Fix installers page being loaded incorrectly

### DIFF
--- a/templates/installers/view.html
+++ b/templates/installers/view.html
@@ -57,7 +57,7 @@
       <div role="tabpanel" class="tab-pane active" id="installer-yaml" aria-labelledby="installer-yaml">
         <pre class="text-white">{{installer.as_cleaned_yaml}}</pre>
       </div>
-      <div role="tabpanel" class="tab-pane active" id="installer-full-yaml" aria-labelledby="installer-full-yaml">
+      <div role="tabpanel" class="tab-pane" id="installer-full-yaml" aria-labelledby="installer-full-yaml">
         <pre class="text-white">{{installer.as_yaml}}</pre>
       </div>
       <div role="tabpanel" class="tab-pane" id="installer-json" aria-labelledby="installer-json">


### PR DESCRIPTION
Both `installer-yaml` and `installer-full-yaml` are marked as active, so both of these show up when the page loads. The page corrects itself after switching to a different tab and back.

This fixes the issue by only marking `installer-yaml` as active, which matches the tabs above.