### PR TITLE
More configurable Django settings for self-hosting

### DIFF
--- a/lutrisweb/settings/production.py
+++ b/lutrisweb/settings/production.py
@@ -3,13 +3,15 @@
 from lutrisweb.settings.base import *  # noqa
 
 DEBUG = False
-ROOT_URL = "https://lutris.net"
+ROOT_URL = os.environ.get("LUTRIS_ROOT_URL", "https://lutris.net")
 DASHBOARD_URL = "https://dashboard.lutris.net"
 MEDIA_URL = f'//{DOMAIN_NAME}/media/'
-FILES_ROOT = '/srv/files'
+FILES_ROOT =  os.environ.get("LUTRIS_FILES_ROOT", '/srv/files')
 FILES_URL = f'https://{DOMAIN_NAME}/files/'
 
-ALLOWED_HOSTS = ('.lutris.net', '.lutr.is', '0.0.0.0', 'localhost')
+ALLOWED_HOSTS = os.environ.get(
+    "LUTRIS_ALLOWED_HOSTS", ".lutris.net,.lutr.is,0.0.0.0,localhost"
+).split(",")
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Those settings seem critical. Self-hosting should benefit from them being configurable.