### PR TITLE
FEAT: Update the Download Steps for Debian

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -109,8 +109,8 @@
           <br/>
           You can add a repository using terminal to receive automatic updates:<br/>
           <br/>
-          <code>echo "deb [signed-by=/etc/apt/keyrings/lutris.gpg] https://download.opensuse.org/repositories/home:/strycore/Debian_12/ ./" |
-            sudo tee /etc/apt/sources.list.d/lutris.list > /dev/null</code><br/>
+          <code>echo -e "Types: deb\nURIs: https://download.opensuse.org/repositories/home:/strycore/Debian_12/\nSuites: ./\nComponents: \nSigned-By: /etc/apt/keyrings/lutris.gpg" |
+            sudo tee /etc/apt/sources.list.d/lutris.sources > /dev/null</code><br/>
           <code>wget -q -O- https://download.opensuse.org/repositories/home:/strycore/Debian_12/Release.key |
             gpg --dearmor |
             sudo tee /etc/apt/keyrings/lutris.gpg > /dev/null</code><br/>


### PR DESCRIPTION
For Debian, change the package list file to the new `.source` standard (**deb822**). The old `.list` format will be deprecated in the feature.

Preview of the resultant `.source` file:
```source
Types: deb
URIs: https://download.opensuse.org/repositories/home:/strycore/Debian_12/
Suites: ./
Components: 
Signed-By: /etc/apt/keyrings/lutris.gpg
```

More about the **deb822**:
- <https://manpages.debian.org/unstable/apt/sources.list.5.en.html>
- <https://repolib.readthedocs.io/en/latest/deb822-format.html>