### PR TITLE
downloads: pop! shop -> cosmic store

### DIFF
--- a/templates/common/downloads.html
+++ b/templates/common/downloads.html
@@ -42,7 +42,7 @@
           </li>
         </ul>
         <p>
-          Lutris is available on Pop!_OS through the <a href="appstream://net.lutris.Lutris">COSMIC Store</a>.
+          Lutris is available on Pop!_OS through the <a href="appstream:net.lutris.Lutris">COSMIC Store</a>.
         </p>
       </li>
       <li>


### PR DESCRIPTION
as of pop!_os 24.04, pop! shop has been replaced with COSMIC store, see https://system76.com/pop/download/ (ctrl+f for "store")