### PR TITLE
Fix a11y: Add aria-labels to social media links in footer

### DIFF
--- a/templates/includes/_footer.html
+++ b/templates/includes/_footer.html
@@ -3,17 +3,17 @@
 <footer id="footer" class="bg-darker py-3 text-lighter d-flex justify-content-center">
   <div class="row">
     <div class="col mx-3">
-      <a href="https://github.com/lutris" class="border-0">
+      <a href="https://github.com/lutris" class="border-0" aria-label="Lutris on Github">
         <i class="bi-github" style="font-size: 2rem;"></i>
       </a>
     </div>
     <div class="col mx-3">
-      <a href="https://fosstodon.org/@lutris" class="border-0">
+      <a href="https://fosstodon.org/@lutris" class="border-0" aria-label="Lutris on Mastodon">
         <i class="bi-mastodon" style="font-size: 2rem;"></i>
       </a>
     </div>
     <div class="col mx-3">
-      <a href="{{ DISCORD_URL }}" class="border-0">
+      <a href="{{ DISCORD_URL }}" class="border-0" aria-label="Lutris on Discord">
           <i class="bi-discord" style="font-size: 2rem;"></i>
       </a>
     </div>


### PR DESCRIPTION


## Summary
This PR resolves 3 accessibility violations by adding aria-label attributes to icon-only social media links in the footer.

## Problem
<img width="2560" height="852" alt="image" src="https://github.com/user-attachments/assets/d6a01898-a2e5-4eaa-8195-a8ea555dc040" />

The IBM Equal Access Accessibility Checker identified that three `<a>` elements containing only icon fonts were missing accessible names, violating WCAG guidelines. These links use Bootstrap Icons (`.bi-github`, `.bi-mastodon`, `.bi-discord`) without any text content, making them inaccessible to screen reader users.

- Violation: Hyperlinks must have an accessible name for their purpose
- Impact: Users relying on assistive technologies could not identify the destination or purpose of these social media links.

**Why is this important?**
When the purpose of a link is clear users can easily navigate links on the page without having to see the surrounding information for context.

## Solution
Added descriptive aria-label attributes to all three icon-only social media links in the footer:

- GitHub link: `aria-label="Lutris on Github"`
- Mastodon link: `aria-label="Lutris on Mastodon"`
- Discord link: `aria-label="Lutris on Discord"`

## Changes

- Added aria-label attributes to 3 `<a>` elements in `templates/includes/_footer.html`
- Labels clearly identify both the platform and the organization (Lutris)
- No visual changes to the UI

## Testing
✅ All 3 accessibility violations resolved
✅ Screen readers now announce meaningful link purposes
✅ Links remain functional and properly styled
✅ Visual presentation unchanged