### PR TITLE
Update list of no-Anticheat recommendations

### DIFF
--- a/games/views/pages.py
+++ b/games/views/pages.py
@@ -274,7 +274,7 @@ def game_detail(request, slug):
                 "counter-strike-2",
                 "farlight-84",
                 "overwatch-2",
-                "apex-legends",
+                "deadlock--2",
             ]
         )
     else:


### PR DESCRIPTION
Apex Legends has disabled Linux support about 2 years ago (see [Twitter announcement](https://twitter.com/PlayApex/status/1852019667315102151)).
The [Apex Legends page](https://lutris.net/games/apex-legends/) has now also been updated to reflect this.

Consequently, we should not present users with Apex Legends as an alternative just to be greeted with the same Anti Cheat notice.

I chose Deadlock because.. why not, but if you prefer something else I can adjust it. Deadlock being a Valve game is extremely unlikely to ever be blocked though, so that's a bonus.